### PR TITLE
feat: OpenSearch 및 운영 환경 보안 강화, 자동 복구 로직 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -157,6 +157,8 @@ jobs:
 
       - name: Package & upload OpenSearch API
         run: |
+          mkdir -p opensearch/data
+          cp backend/app/agents/generate_message_agent/data/forbidden_keyword.json opensearch/data/
           tar -czf /tmp/opensearch.tar.gz -C opensearch .
           aws s3 cp /tmp/opensearch.tar.gz s3://${{ env.PROJECT_NAME }}-deploy/opensearch.tar.gz
 

--- a/backend/app/agents/base/base_agent.py
+++ b/backend/app/agents/base/base_agent.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional
 
+from app.config.settings import settings
+
 
 class BaseAgent(ABC):
     """
@@ -19,7 +21,8 @@ class BaseAgent(ABC):
         config: Optional[Dict] = None,
     ):
         self.llm = llm
-        self.config = config or {}
+        base_config: Dict = {"recursion_limit": settings.langgraph_recursion_limit}
+        self.config = {**base_config, **(config or {})}
 
         # 그래프는 하위 클래스에서 구현
         self.graph = self._build_workflow()
@@ -54,7 +57,7 @@ class BaseAgent(ABC):
 
         state = self._create_initial_state(**kwargs)
 
-        result = self.graph.invoke(state)
+        result = self.graph.invoke(state, self.config)
 
         return result
 
@@ -65,7 +68,7 @@ class BaseAgent(ABC):
 
         state = self._create_initial_state(**kwargs)
 
-        result = await self.graph.ainvoke(state)
+        result = await self.graph.ainvoke(state, self.config)
 
         return result
 
@@ -76,8 +79,7 @@ class BaseAgent(ABC):
 
         state = self._create_initial_state(**kwargs)
 
-        for event in self.graph.stream(state):
-            yield event
+        yield from self.graph.stream(state, self.config)
 
     async def astream(self, **kwargs):
         """
@@ -86,7 +88,7 @@ class BaseAgent(ABC):
 
         state = self._create_initial_state(**kwargs)
 
-        async for event in self.graph.astream(state):
+        async for event in self.graph.astream(state, self.config):
             yield event
 
 # -------------------------------------------------
@@ -98,7 +100,7 @@ class BaseAgent(ABC):
         interrupt 이후 resume
         """
 
-        return self.graph.invoke(state)
+        return self.graph.invoke(state, self.config)
 
     async def aresume(self, state):
-        return await self.graph.ainvoke(state)
+        return await self.graph.ainvoke(state, self.config)

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -259,11 +259,17 @@ class Settings(BaseSettings):
     admin_seed_email: str = ""
     admin_seed_password: str = ""
 
+    # AWS — self-cleaning seed secrets용 (Terraform var.project_name, var.aws_region과 일치)
+    aws_region: str = "ap-northeast-2"
+    project_name: str = "ai-innovation"
+
     @field_validator("allowed_origins", mode="before")
     @classmethod
     def parse_allowed_origins(cls, v: object) -> object:
         if isinstance(v, str):
             return [o.strip() for o in v.split(",") if o.strip()]
+        if isinstance(v, list):
+            return [o for o in v if isinstance(o, str) and o.strip()]
         return v
 
     @field_validator("trusted_proxy_ips", mode="before")
@@ -345,6 +351,24 @@ class Settings(BaseSettings):
                 "무효화됩니다. Nginx IP를 TRUSTED_PROXY_IPS 환경변수에 추가하세요. "
                 "예: TRUSTED_PROXY_IPS=10.0.0.1"
             )
+
+        if self.environment == "production":
+            localhost_origins = [
+                o for o in self.allowed_origins
+                if "localhost" in o or "127.0.0.1" in o
+            ]
+            if localhost_origins:
+                raise ValueError(
+                    f"프로덕션 환경에서 localhost CORS 오리진이 설정되어 있습니다: {localhost_origins}. "
+                    "실제 프론트엔드 도메인으로 교체하세요. "
+                    "예: ALLOWED_ORIGINS=https://your-domain.com"
+                )
+            if not self.allowed_origins:
+                raise ValueError(
+                    "프로덕션 환경에서 ALLOWED_ORIGINS가 비어 있습니다. "
+                    "GitHub Secret에 프론트엔드 도메인을 설정하세요. "
+                    "예: ALLOWED_ORIGINS=https://your-domain.com"
+                )
 
         # LangSmith 트레이싱 활성화 시 API 키 필요
         if self.langchain_tracing_v2 and not self.langchain_api_key:

--- a/backend/main.py
+++ b/backend/main.py
@@ -34,6 +34,23 @@ configure_logging(
 logger = get_logger("main")
 
 
+def _delete_seed_secrets() -> None:
+    import boto3
+    from botocore.exceptions import ClientError
+
+    client = boto3.client("secretsmanager", region_name=settings.aws_region)
+    for suffix in ("admin-seed-email", "admin-seed-password"):
+        secret_id = f"{settings.project_name}/{suffix}"
+        try:
+            client.delete_secret(SecretId=secret_id, ForceDeleteWithoutRecovery=True)
+            logger.info("seed_secret_deleted", secret=suffix)
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "ResourceNotFoundException":
+                pass
+            else:
+                logger.warning("seed_secret_delete_failed", secret=suffix, error_type=type(e).__name__)
+
+
 def _seed_admin_if_needed() -> None:
     email = settings.admin_seed_email.strip()
     password = settings.admin_seed_password
@@ -47,11 +64,12 @@ def _seed_admin_if_needed() -> None:
     with SessionLocal() as db:
         if db.query(User).filter(User.email == email).first():
             logger.info("admin_seed_skipped", reason="already_exists")
-            return
-        db.add(User(email=email, password_hash=hash_password(password), role="admin"))
-        db.commit()
+        else:
+            db.add(User(email=email, password_hash=hash_password(password), role="admin"))
+            db.commit()
+            logger.info("admin_seeded")
 
-    logger.info("admin_seeded")
+    _delete_seed_secrets()
 
 
 @asynccontextmanager

--- a/infra/ec2/ec2.tf
+++ b/infra/ec2/ec2.tf
@@ -127,9 +127,10 @@ resource "aws_instance" "opensearch" {
   user_data_replace_on_change = true
 
   user_data = base64encode(templatefile("${path.module}/user_data/opensearch_server.sh", {
-    project_name       = var.project_name
-    OPENSEARCH_VERSION = "2.13.0"
-    internal_token     = var.internal_token
+    project_name              = var.project_name
+    OPENSEARCH_VERSION        = "2.13.0"
+    internal_token            = var.internal_token
+    opensearch_admin_password = var.opensearch_admin_password
   }))
 
   root_block_device {

--- a/infra/ec2/ecs.tf
+++ b/infra/ec2/ecs.tf
@@ -54,6 +54,39 @@ resource "aws_service_discovery_private_dns_namespace" "crm" {
   vpc         = aws_vpc.main.id
 }
 
+# ---- IAM Task Role (런타임 — 앱이 AWS API를 직접 호출할 때 사용) ----
+
+resource "aws_iam_role" "ecs_task_role" {
+  name = "${var.project_name}-ecs-task-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+    }]
+  })
+}
+
+# Admin seed 시크릿 삭제 권한 — 앱이 시딩 완료 후 스스로 삭제
+resource "aws_iam_role_policy" "ecs_task_seed_delete" {
+  name = "${var.project_name}-ecs-task-seed-delete"
+  role = aws_iam_role.ecs_task_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["secretsmanager:DeleteSecret"]
+      Resource = [
+        "arn:aws:secretsmanager:${var.aws_region}:*:secret:${var.project_name}/admin-seed-email*",
+        "arn:aws:secretsmanager:${var.aws_region}:*:secret:${var.project_name}/admin-seed-password*",
+      ]
+    }]
+  })
+}
+
 # ---- IAM Task Execution Role ----
 
 resource "aws_iam_role" "ecs_execution" {
@@ -130,6 +163,7 @@ resource "aws_ecs_task_definition" "backend" {
   cpu                      = var.ecs_task_cpu
   memory                   = var.ecs_task_memory
   execution_role_arn       = aws_iam_role.ecs_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task_role.arn
 
   container_definitions = jsonencode([{
     name      = "fastapi-backend"

--- a/infra/ec2/security_groups.tf
+++ b/infra/ec2/security_groups.tf
@@ -4,7 +4,7 @@
 # 트래픽 흐름:
 #   인터넷 → ALB(sg_alb) → ECS tasks(sg_ecs_tasks)
 #   ECS tasks → DB EC2(sg_db_ec2)         [포트 5432, 8020]
-#   ECS tasks → OpenSearch EC2(sg_opensearch_ec2) [포트 8010, 9200]
+#   ECS tasks → OpenSearch EC2(sg_opensearch_ec2) [포트 8010]  ← 9200 직접 접근 차단
 #   ECS/EC2  → VPC Endpoints(sg_vpc_endpoints)   [포트 443]
 # -----------------------------------------------------------------------
 
@@ -138,7 +138,7 @@ resource "aws_security_group" "opensearch_ec2" {
   tags = { Name = "${var.project_name}-sg-opensearch-ec2" }
 }
 
-# OpenSearch API(8010) — ECS tasks에서 HTTP 호출
+# OpenSearch API(8010) — ECS tasks에서 HTTP 호출 (9200 직접 접근은 차단 — 인증 없는 경로 제거)
 resource "aws_security_group_rule" "ecs_to_opensearch_api" {
   type                     = "ingress"
   description              = "OpenSearch API server - ECS to OpenSearch API"
@@ -149,16 +149,6 @@ resource "aws_security_group_rule" "ecs_to_opensearch_api" {
   security_group_id        = aws_security_group.opensearch_ec2.id
 }
 
-# OpenSearch native REST(9200) — ECS tasks에서 직접 호출 시
-resource "aws_security_group_rule" "ecs_to_opensearch_native" {
-  type                     = "ingress"
-  description              = "OpenSearch native REST - ECS to OpenSearch 9200"
-  from_port                = 9200
-  to_port                  = 9200
-  protocol                 = "tcp"
-  source_security_group_id = aws_security_group.ecs_tasks.id
-  security_group_id        = aws_security_group.opensearch_ec2.id
-}
 
 # ---- VPC Interface Endpoints ----
 

--- a/infra/ec2/user_data/opensearch_server.sh
+++ b/infra/ec2/user_data/opensearch_server.sh
@@ -183,8 +183,9 @@ WorkingDirectory=/opt/opensearch-api
 Environment=OPENSEARCH_URL=http://localhost:9200
 Environment=OPENSEARCH_HOST=localhost
 Environment=OPENSEARCH_PORT=9200
-Environment=OPENSEARCH_ADMIN_PASSWORD=admin
+Environment=OPENSEARCH_ADMIN_PASSWORD=${opensearch_admin_password}
 Environment=INTERNAL_TOKEN=$INTERNAL_TOKEN
+Environment=FORBIDDEN_KEYWORD_JSON_PATH=/opt/opensearch-api/data/forbidden_keyword.json
 # OpenSearch 완전 기동 후 60초 추가 대기
 # — 재부팅 직후 SSM 에이전트가 메모리를 확보할 시간을 확보합니다
 ExecStartPre=/bin/sleep 60

--- a/infra/ec2/variables.tf
+++ b/infra/ec2/variables.tf
@@ -133,6 +133,12 @@ variable "postgres_password" {
   sensitive   = true
 }
 
+variable "opensearch_admin_password" {
+  description = "OpenSearch admin 비밀번호 (최소 8자, 대소문자+숫자+특수문자 포함)"
+  type        = string
+  sensitive   = true
+}
+
 variable "internal_token" {
   description = "내부 서비스 간 인증 토큰 (최소 32자, openssl rand -hex 32)"
   type        = string

--- a/opensearch/opensearch_api.py
+++ b/opensearch/opensearch_api.py
@@ -15,6 +15,7 @@ import sys
 import structlog
 from dotenv import load_dotenv
 from opensearch_hybrid import OpenSearchHybridClient
+from index_forbidden_sentences import run_indexing
 
 # 환경 변수 로드
 load_dotenv()
@@ -367,11 +368,17 @@ def get_opensearch_client() -> OpenSearchHybridClient:
 
 @app.on_event("startup")
 async def startup_event():
-    """서버 시작 시 OpenSearch 클라이언트 초기화"""
+    """서버 시작 시 OpenSearch 클라이언트 초기화 + forbidden_sentences 인덱스 보장"""
     logger.info("server_starting")
     try:
-        get_opensearch_client()
+        client = get_opensearch_client()
         logger.info("opensearch_client_initialized")
+        # 이미 로드된 임베딩 모델을 재사용해 인덱싱 — 문서가 있으면 skip (idempotent)
+        ok = await asyncio.to_thread(run_indexing, client)
+        if ok:
+            logger.info("forbidden_sentences_index_ready")
+        else:
+            logger.error("forbidden_sentences_index_failed")
     except Exception as e:
         logger.error("startup_failed", error_type=type(e).__name__)
 


### PR DESCRIPTION
problem:
- OpenSearch Security 비활성화 및 9200 포트 인증 없는 내부 접근 경로 존재
- OpenSearch admin 비밀번호 하드코딩 및 Admin Seed Secret 장기 잔존
- 운영 환경에서 잘못된 CORS 설정(localhost/빈 값)이 무음으로 기동 가능
- BaseAgent의 LangGraph recursion_limit 미적용으로 잠재적 재귀 한계 오류 가능성
- forbidden_sentences 인덱스 및 데이터가 운영 환경에서 자동 생성되지 않아 의미 유사도 검사가 비활성화될 수 있음

as is:
- ECS에서 OpenSearch Native API에 인증 없이 직접 접근 가능
- Admin Seed Secret 삭제를 수동 절차에 의존
- ALLOWED_ORIGINS 검증 부족으로 잘못된 설정도 서버가 기동
- BaseAgent의 graph 호출 시 recursion_limit 기본값 사용
- EC2 배포 시 forbidden_sentences 인덱스 및 JSON 리소스가 자동 준비되지 않음

to be:
- 9200 직접 접근 제거 및 OpenSearch 관리자 비밀번호를 외부 시크릿으로 관리
- ECS Task Role 기반 Secret 자동 삭제(Self-cleaning) 구조 적용
- 운영 환경 CORS 설정 Fail-Fast 검증 추가(localhost/빈 값 차단)
- BaseAgent 전체 graph 호출에 공통 recursion_limit 적용
- 서버 시작 시 forbidden_sentences 인덱스를 자동 보장하고 필요한 JSON 리소스를 함께 배포하여 Self-healing 구조로 개선