### PR TITLE
fix: Terraform Apply 시 OpenSearch Admin 비밀번호 누락으로 인한 배포 블로킹 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,6 +103,7 @@ jobs:
           TF_VAR_ecr_image_tag: ${{ github.sha }}
 
           # ── 시크릿 (GitHub Secrets에서 주입) ──
+          TF_VAR_opensearch_admin_password: ${{ secrets.OPENSEARCH_ADMIN_PASSWORD }}
           TF_VAR_postgres_password:    ${{ secrets.POSTGRES_PASSWORD }}
           TF_VAR_internal_token:       ${{ secrets.INTERNAL_TOKEN }}
           TF_VAR_jwt_secret:           ${{ secrets.JWT_SECRET }}


### PR DESCRIPTION
problem:
- GitHub Actions에서 terraform apply -auto-approve 실행 시 opensearch_admin_password 입력을 기다리며 무한 대기
- CI 환경에서 OpenSearch Admin 비밀번호가 전달되지 않아 자동 배포가 중단됨

as is:
- opensearch_admin_password는 필수 Terraform 변수지만 TF_VAR_opensearch_admin_password가 워크플로우에 주입되지 않음
- -auto-approve는 변수 입력 프롬프트를 건너뛰지 못해 CI/CD가 stdin 입력 대기 상태로 블로킹됨

to be:
- GitHub Secret OPENSEARCH_ADMIN_PASSWORD를 TF_VAR_opensearch_admin_password로 Terraform에 전달
- 기존 시크릿 주입 패턴과 일관성을 유지하면서 OpenSearch 초기화에 필요한 민감 정보를 안전하게 제공
- Terraform Apply가 사용자 입력 없이 정상적으로 완료되도록 수정