### PR TITLE
fix: upgrade OpenSearch EC2 instance type to t3.large

### DIFF
--- a/infra/ec2/variables.tf
+++ b/infra/ec2/variables.tf
@@ -53,7 +53,7 @@ variable "db_instance_type" {
 variable "opensearch_instance_type" {
   description = "OpenSearch EC2 인스턴스 타입"
   type        = string
-  default     = "t3.medium"
+  default     = "t3.large"
 }
 
 variable "ec2_ami" {


### PR DESCRIPTION
problem:
t3.medium(4GB)에서 OpenSearch JVM(1.2GB) + KURE-v1(1.5GB) 동시 기동 시
         메모리 92MB만 남아 write 스레드 OOM → 2~3분마다 크래시 반복

as is:
opensearch_instance_type = t3.medium (4GB RAM)

to be:
opensearch_instance_type = t3.large (8GB RAM) → 여유 메모리 ~4GB 확보