### PR TITLE
fix: remove forbidden_sentences startup indexing + revert to t3.medium

### DIFF
--- a/infra/ec2/variables.tf
+++ b/infra/ec2/variables.tf
@@ -53,7 +53,7 @@ variable "db_instance_type" {
 variable "opensearch_instance_type" {
   description = "OpenSearch EC2 인스턴스 타입"
   type        = string
-  default     = "t3.large"
+  default     = "t3.medium"
 }
 
 variable "ec2_ami" {

--- a/opensearch/opensearch_api.py
+++ b/opensearch/opensearch_api.py
@@ -15,7 +15,6 @@ import sys
 import structlog
 from dotenv import load_dotenv
 from opensearch_hybrid import OpenSearchHybridClient
-from index_forbidden_sentences import run_indexing
 
 # 환경 변수 로드
 load_dotenv()
@@ -368,17 +367,11 @@ def get_opensearch_client() -> OpenSearchHybridClient:
 
 @app.on_event("startup")
 async def startup_event():
-    """서버 시작 시 OpenSearch 클라이언트 초기화 + forbidden_sentences 인덱스 보장"""
+    """서버 시작 시 OpenSearch 클라이언트 초기화"""
     logger.info("server_starting")
     try:
-        client = get_opensearch_client()
+        get_opensearch_client()
         logger.info("opensearch_client_initialized")
-        # 이미 로드된 임베딩 모델을 재사용해 인덱싱 — 문서가 있으면 skip (idempotent)
-        ok = await asyncio.to_thread(run_indexing, client)
-        if ok:
-            logger.info("forbidden_sentences_index_ready")
-        else:
-            logger.error("forbidden_sentences_index_failed")
     except Exception as e:
         logger.error("startup_failed", error_type=type(e).__name__)
 


### PR DESCRIPTION
Problem:
startup에서 run_indexing이 매 재시작마다 bulk re-indexing → OpenSearch
         write 스레드 크래시 → Requires= 연쇄 재시작 무한 루프

as is:
startup_event에서 run_indexing 호출, opensearch_instance_type = t3.large

to be:
startup은 클라이언트 초기화만 수행, opensearch_instance_type = t3.medium