### PR TITLE
fix: resolve CRM crash loop and CloudFront timeout

### DIFF
--- a/infra/ec2/cloudfront.tf
+++ b/infra/ec2/cloudfront.tf
@@ -60,6 +60,11 @@ resource "aws_cloudfront_distribution" "frontend" {
       https_port             = 443
       origin_protocol_policy = "http-only"
       origin_ssl_protocols   = ["TLSv1.2"]
+      # 기본값 30s → 최대 60s로 증가
+      # 페르소나 업로드: 파일 읽기(30s) + 파싱(15s) = 최대 45s 소요
+      # SSE 스트리밍: keepalive 25s 간격, 30s 미만 여유 없음
+      origin_read_timeout      = 60
+      origin_keepalive_timeout = 5
     }
   }
 

--- a/infra/ec2/ecs.tf
+++ b/infra/ec2/ecs.tf
@@ -139,6 +139,9 @@ locals {
     { name = "PARSER_MODEL_NAME",    value = var.parser_model_name },
     { name = "ENVIRONMENT",          value = var.environment },
     { name = "LOG_LEVEL",            value = "INFO" },
+    # ALLOWED_ORIGINS: 모든 서비스에 주입 — Settings 프로덕션 검증이 localhost를 거부하므로
+    # CRM·recommend·generate·data-registration 같은 내부 서비스도 이 값이 필요함
+    { name = "ALLOWED_ORIGINS",      value = jsonencode(split(",", var.allowed_origins)) },
     # TRUSTED_PROXY_IPS: ALB는 VPC 프라이빗 서브넷에서 ECS로 전달
     # ALB가 신뢰 프록시이므로 프라이빗 서브넷 CIDR을 허용
     { name = "TRUSTED_PROXY_IPS",    value = jsonencode(var.private_subnet_cidrs) },
@@ -170,9 +173,7 @@ resource "aws_ecs_task_definition" "backend" {
     image     = "${var.ecr_registry}/${var.project_name}-backend:${var.ecr_image_tag}"
     essential = true
     portMappings = [{ containerPort = 8005, protocol = "tcp" }]
-    environment  = concat(local.common_env, local.a2a_env, [
-      { name = "ALLOWED_ORIGINS", value = jsonencode(split(",", var.allowed_origins)) },
-    ])
+    environment  = concat(local.common_env, local.a2a_env)
     # Secrets Manager — ECS가 태스크 시작 시 주입, 태스크 정의 JSON에 값 미노출
     secrets = local.admin_seed_enabled ? [
       {


### PR DESCRIPTION
problem
- CRM/recommend/generate/data-registration 서비스가 시작 시 즉시 crash
- 페르소나 파일 업로드 504 Gateway Timeout
- 에이전트 채팅 no_result 에러

as is
- ALLOWED_ORIGINS가 backend task definition에만 설정되어 있어 나머지 내부 서비스는 기본값 http://localhost:3000 사용
- production 환경에서 Settings 검증이 localhost CORS를 거부 → CRM 등 내부 서비스 import 단계에서 ValidationError crash
- CloudFront origin_read_timeout 기본값 30s → 파일 업로드(최대 45s) 및 SSE keepalive(25s 간격) 타임아웃 초과

to be
- ALLOWED_ORIGINS를 common_env로 이동하여 모든 ECS 서비스에 동일하게 주입
- CRM/recommend/generate/data-registration Settings 검증 통과 → 정상 기동
- CloudFront origin_read_timeout 60s로 증가 → 업로드 504 해소, SSE 연결 안정화