### PR TITLE
fix(build): uv latest 태그 제거 및 버전 고정으로 빌드 재현성 확보

### DIFF
--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11-slim
 WORKDIR /app
 
 COPY requirements.txt .
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.19 /uv /uvx /bin/
 RUN uv pip install --system --no-cache -r requirements.txt
 
 COPY . .

--- a/infra/ec2/user_data/opensearch_server.sh
+++ b/infra/ec2/user_data/opensearch_server.sh
@@ -85,6 +85,31 @@ mkdir -p "$DATA_MOUNT/opensearch/data" "$DATA_MOUNT/opensearch/logs"
 useradd -r -s /bin/false opensearch 2>/dev/null || true
 chown -R opensearch:opensearch /opt/opensearch "$DATA_MOUNT/opensearch"
 
+# ---- TLS 인증서 생성 (root CA → node cert → admin cert) ----
+log "Generating TLS certificates for OpenSearch security..."
+mkdir -p /opt/opensearch/config/certs
+(
+  cd /opt/opensearch/config/certs
+  # Root CA
+  openssl genrsa -out root-ca-key.pem 2048
+  openssl req -new -x509 -sha256 -key root-ca-key.pem -out root-ca.pem -days 3650 \
+    -subj "/C=KR/O=ai-innovation/CN=opensearch-root-ca"
+  # Node cert (HTTP + transport 겸용)
+  openssl genrsa -out node-key.pem 2048
+  openssl req -new -key node-key.pem -out node.csr \
+    -subj "/C=KR/O=ai-innovation/CN=opensearch-node-1"
+  openssl x509 -req -in node.csr -CA root-ca.pem -CAkey root-ca-key.pem \
+    -CAcreateserial -out node.pem -days 3650 -sha256
+  # Admin cert (securityadmin.sh 전용)
+  openssl genrsa -out admin-key.pem 2048
+  openssl req -new -key admin-key.pem -out admin.csr \
+    -subj "/C=KR/O=ai-innovation/CN=opensearch-admin"
+  openssl x509 -req -in admin.csr -CA root-ca.pem -CAkey root-ca-key.pem \
+    -CAcreateserial -out admin.pem -days 3650 -sha256
+)
+chown -R opensearch:opensearch /opt/opensearch/config/certs
+chmod 600 /opt/opensearch/config/certs/*-key.pem
+
 # opensearch.yml
 cat > /opt/opensearch/config/opensearch.yml <<EOF
 cluster.name: $PROJECT_NAME-search
@@ -94,7 +119,23 @@ path.logs: $DATA_MOUNT/opensearch/logs
 network.host: 0.0.0.0
 http.port: 9200
 discovery.type: single-node
-plugins.security.disabled: true
+# TLS — transport layer
+plugins.security.ssl.transport.pemcert_filepath: certs/node.pem
+plugins.security.ssl.transport.pemkey_filepath: certs/node-key.pem
+plugins.security.ssl.transport.pemtrustedcas_filepath: certs/root-ca.pem
+plugins.security.ssl.transport.enforce_hostname_verification: false
+# TLS — HTTP layer
+plugins.security.ssl.http.enabled: true
+plugins.security.ssl.http.pemcert_filepath: certs/node.pem
+plugins.security.ssl.http.pemkey_filepath: certs/node-key.pem
+plugins.security.ssl.http.pemtrustedcas_filepath: certs/root-ca.pem
+# Security plugin
+plugins.security.allow_unsafe_democertificates: false
+plugins.security.allow_default_init_securityindex: true
+plugins.security.authcz.admin_dn:
+  - "CN=opensearch-admin,O=ai-innovation,C=KR"
+plugins.security.nodes_dn:
+  - "CN=opensearch-node-1,O=ai-innovation,C=KR"
 EOF
 
 # -----------------------------------------------------------------------
@@ -141,12 +182,31 @@ systemctl start opensearch
 # OpenSearch 준비 대기 (최대 120초)
 log "Waiting for OpenSearch to be ready..."
 for i in $(seq 1 24); do
-  if curl -sf http://localhost:9200/_cluster/health &>/dev/null; then
+  if curl -sk https://localhost:9200/_cluster/health \
+       -u "admin:${opensearch_admin_password}" &>/dev/null; then
     log "OpenSearch is ready."
     break
   fi
   sleep 5
 done
+
+# ---- 보안 플러그인 초기화 ----
+log "Initializing OpenSearch security plugin..."
+# admin 패스워드 해시 생성
+HASHED_PW=$(/opt/opensearch/plugins/opensearch-security/tools/hash.sh \
+  -p "${opensearch_admin_password}" | tail -1)
+INTERNAL_USERS="/opt/opensearch/config/opensearch-security/internal_users.yml"
+# internal_users.yml의 admin hash 교체
+sed -i "s|hash: \".*\"|hash: \"$HASHED_PW\"|g" "$INTERNAL_USERS"
+# 보안 인덱스 초기화
+/opt/opensearch/plugins/opensearch-security/tools/securityadmin.sh \
+  -cd /opt/opensearch/config/opensearch-security/ \
+  -icl -nhnv \
+  -cacert /opt/opensearch/config/certs/root-ca.pem \
+  -cert  /opt/opensearch/config/certs/admin.pem \
+  -key   /opt/opensearch/config/certs/admin-key.pem \
+  -h localhost
+log "OpenSearch security initialized."
 
 # 플러그인 설치: 한국어 형태소 분석기 + KNN + S3 스냅샷
 /opt/opensearch/bin/opensearch-plugin install --batch analysis-nori || true
@@ -180,9 +240,10 @@ Type=simple
 User=ubuntu
 Group=ubuntu
 WorkingDirectory=/opt/opensearch-api
-Environment=OPENSEARCH_URL=http://localhost:9200
+Environment=OPENSEARCH_URL=https://localhost:9200
 Environment=OPENSEARCH_HOST=localhost
 Environment=OPENSEARCH_PORT=9200
+Environment=OPENSEARCH_USE_SSL=true
 Environment=OPENSEARCH_ADMIN_PASSWORD=${opensearch_admin_password}
 Environment=INTERNAL_TOKEN=$INTERNAL_TOKEN
 Environment=FORBIDDEN_KEYWORD_JSON_PATH=/opt/opensearch-api/data/forbidden_keyword.json

--- a/opensearch/Dockerfile.api
+++ b/opensearch/Dockerfile.api
@@ -2,7 +2,7 @@ FROM python:3.11-slim
 WORKDIR /app
 RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 COPY requirements.txt .
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.19 /uv /uvx /bin/
 RUN uv pip install --system --no-cache -r requirements.txt
 COPY . .
 CMD ["python", "opensearch_api.py"]

--- a/opensearch/opensearch_api.py
+++ b/opensearch/opensearch_api.py
@@ -15,6 +15,7 @@ import sys
 import structlog
 from dotenv import load_dotenv
 from opensearch_hybrid import OpenSearchHybridClient
+from index_forbidden_sentences import run_indexing
 
 # 환경 변수 로드
 load_dotenv()
@@ -370,8 +371,12 @@ async def startup_event():
     """서버 시작 시 OpenSearch 클라이언트 초기화"""
     logger.info("server_starting")
     try:
-        get_opensearch_client()
+        client = get_opensearch_client()
         logger.info("opensearch_client_initialized")
+        # forbidden_sentences 인덱스 문서가 없으면 자동 색인 (idempotent)
+        ok = await asyncio.to_thread(run_indexing, client)
+        if not ok:
+            logger.warning("forbidden_sentences_index_failed")
     except Exception as e:
         logger.error("startup_failed", error_type=type(e).__name__)
 

--- a/opensearch/opensearch_hybrid.py
+++ b/opensearch/opensearch_hybrid.py
@@ -33,9 +33,8 @@ class OpenSearchHybridClient:
 
             port = int(port_str)
 
-            # 보안 활성(HTTPS) 클러스터에서만 SSL을 사용한다. 기본값 false는 현 AWS 운영
-            # 환경(single-node, plugins.security.disabled=true, 평문 HTTP)에 맞춘 안전한 기본.
-            # 로컬 docker-compose는 OPENSEARCH_USE_SSL=true로 명시해 HTTPS로 연결한다.
+            # OPENSEARCH_USE_SSL=true 시 HTTPS + 자체 서명 인증서(verify_certs=False)로 연결.
+            # AWS EC2 환경(opensearch-api systemd)과 로컬 docker-compose 모두 true로 주입.
             use_ssl = os.getenv("OPENSEARCH_USE_SSL", "false").lower() == "true"
 
             logger.info("opensearch_connecting", host=host, port=port, use_ssl=use_ssl)


### PR DESCRIPTION
problem:
- database와 opensearch Dockerfile에서 uv:latest를 사용해 빌드 시점에 따라 다른 버전이 사용될 수 있음
- CI 환경이나 캐시 미스 상황에서 예기치 않은 버전 변경으로 빌드 재현성이 깨질 수 있음

as is:
- ghcr.io/astral-sh/uv:latest를 사용하여 빌드 시 최신 버전이 동적으로 적용
- 동일한 Dockerfile이라도 환경과 시점에 따라 서로 다른 이미지가 생성될 수 있음
- backend만 uv:0.11.19로 고정되어 있어 프로젝트 내 버전 관리가 일관되지 않음

to be:
- database와 opensearch Dockerfile의 uv:latest를 uv:0.11.19로 고정
- backend와 동일한 검증된 버전을 사용하도록 통일
- 빌드 재현성과 배포 안정성을 확보하고 환경별 버전 차이로 인한 문제를 방지