### PR TITLE
fix: OpenSearch EC2 user_data 타임아웃 및 인덱싱 스크립트 인증 오류 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -151,6 +151,22 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Cache OpenSearch tarball in S3 (skip if already uploaded)
+        run: |
+          OPENSEARCH_VERSION="2.13.0"
+          S3_KEY="opensearch-${OPENSEARCH_VERSION}-linux-x64.tar.gz"
+          if aws s3 ls "s3://${{ env.PROJECT_NAME }}-deploy/${S3_KEY}" > /dev/null 2>&1; then
+            echo "OpenSearch tarball already cached in S3, skipping."
+          else
+            echo "Downloading OpenSearch ${OPENSEARCH_VERSION} and uploading to S3..."
+            curl -fsSL \
+              "https://artifacts.opensearch.org/releases/bundle/opensearch/${OPENSEARCH_VERSION}/opensearch-${OPENSEARCH_VERSION}-linux-x64.tar.gz" \
+              -o /tmp/opensearch-dist.tar.gz
+            aws s3 cp /tmp/opensearch-dist.tar.gz \
+              "s3://${{ env.PROJECT_NAME }}-deploy/${S3_KEY}"
+            echo "OpenSearch tarball cached."
+          fi
+
       - name: Package & upload Database API
         run: |
           tar -czf /tmp/database.tar.gz -C database .
@@ -248,7 +264,7 @@ jobs:
       - name: Wait for OpenSearch EC2 user_data to complete
         run: |
           echo "Waiting for OpenSearch EC2 user_data to complete..."
-          for i in $(seq 1 60); do
+          for i in $(seq 1 80); do
             RESULT=$(aws ssm send-command \
               --instance-ids "${{ needs.terraform.outputs.opensearch_instance_id }}" \
               --document-name "AWS-RunShellScript" \
@@ -264,8 +280,8 @@ jobs:
               echo "OpenSearch EC2 user_data complete."
               break
             fi
-            if [ "$i" = "60" ]; then
-              echo "ERROR: OpenSearch EC2 user_data did not complete within 30 minutes."
+            if [ "$i" = "80" ]; then
+              echo "ERROR: OpenSearch EC2 user_data did not complete within 40 minutes."
               exit 1
             fi
             sleep 25

--- a/infra/ec2/user_data/opensearch_server.sh
+++ b/infra/ec2/user_data/opensearch_server.sh
@@ -22,6 +22,17 @@ INTERNAL_TOKEN="${internal_token}"
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a /var/log/user-data.log; }
 
 # ---- 1. 시스템 업데이트 ----
+log "Waiting for cloud-init apt lock to release..."
+# Ubuntu 최초 부팅 시 unattended-upgrades가 dpkg lock을 점유 — 해제까지 대기
+systemctl stop unattended-upgrades apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
+systemctl kill --kill-who=all apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
+sleep 5
+for i in $(seq 1 30); do
+  if ! lsof /var/lib/dpkg/lock-frontend 2>/dev/null | grep -q dpkg; then break; fi
+  log "apt lock held, waiting... ($i/30)"
+  sleep 10
+done
+
 log "Updating system packages..."
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -qq
@@ -74,8 +85,25 @@ echo "opensearch hard nofile 65536" >> /etc/security/limits.conf
 
 # ---- 5. OpenSearch 설치 ----
 log "Installing OpenSearch $OPENSEARCH_VERSION..."
-curl -fsSL "https://artifacts.opensearch.org/releases/bundle/opensearch/$${OPENSEARCH_VERSION}/opensearch-$${OPENSEARCH_VERSION}-linux-x64.tar.gz" \
-  -o /tmp/opensearch.tar.gz
+S3_KEY="opensearch-$OPENSEARCH_VERSION-linux-x64.tar.gz"
+# S3 Gateway Endpoint 경유 (NAT 우회, 무료) — package-data-services job이 먼저 캐시
+# 최대 10분 대기 후 fallback
+DOWNLOADED=false
+for i in $(seq 1 20); do
+  if /usr/local/bin/aws s3 cp "s3://$PROJECT_NAME-deploy/$S3_KEY" /tmp/opensearch.tar.gz 2>/dev/null; then
+    log "Downloaded OpenSearch from S3 (attempt $i)."
+    DOWNLOADED=true
+    break
+  fi
+  log "S3 tarball not ready yet, waiting 30s... ($i/20)"
+  sleep 30
+done
+if [ "$DOWNLOADED" = "false" ]; then
+  log "S3 unavailable, falling back to direct download..."
+  curl -fsSL \
+    "https://artifacts.opensearch.org/releases/bundle/opensearch/$${OPENSEARCH_VERSION}/opensearch-$${OPENSEARCH_VERSION}-linux-x64.tar.gz" \
+    -o /tmp/opensearch.tar.gz
+fi
 mkdir -p /opt/opensearch
 tar xzf /tmp/opensearch.tar.gz -C /opt/opensearch --strip-components=1
 rm /tmp/opensearch.tar.gz
@@ -179,52 +207,84 @@ systemctl daemon-reload
 systemctl enable opensearch
 systemctl start opensearch
 
-# OpenSearch 준비 대기 (최대 120초)
+# OpenSearch 준비 대기 (최대 300초)
+# t3.medium에서 JVM 콜드 스타트는 60~150초 소요 — 120초 상한은 부족
 log "Waiting for OpenSearch to be ready..."
-for i in $(seq 1 24); do
+OS_READY=false
+for i in $(seq 1 60); do
   if curl -sk https://localhost:9200/_cluster/health \
        -u "admin:${opensearch_admin_password}" &>/dev/null; then
-    log "OpenSearch is ready."
+    log "OpenSearch is ready (attempt $i)."
+    OS_READY=true
     break
   fi
   sleep 5
 done
+if [ "$OS_READY" = "false" ]; then
+  log "ERROR: OpenSearch did not start within 300 seconds."
+  exit 1
+fi
 
 # ---- 보안 플러그인 초기화 ----
 log "Initializing OpenSearch security plugin..."
-# admin 패스워드 해시 생성
 HASHED_PW=$(/opt/opensearch/plugins/opensearch-security/tools/hash.sh \
   -p "${opensearch_admin_password}" | tail -1)
 INTERNAL_USERS="/opt/opensearch/config/opensearch-security/internal_users.yml"
-# internal_users.yml의 admin hash 교체
 sed -i "s|hash: \".*\"|hash: \"$HASHED_PW\"|g" "$INTERNAL_USERS"
-# 보안 인덱스 초기화
-/opt/opensearch/plugins/opensearch-security/tools/securityadmin.sh \
-  -cd /opt/opensearch/config/opensearch-security/ \
-  -icl -nhnv \
-  -cacert /opt/opensearch/config/certs/root-ca.pem \
-  -cert  /opt/opensearch/config/certs/admin.pem \
-  -key   /opt/opensearch/config/certs/admin-key.pem \
-  -h localhost
-log "OpenSearch security initialized."
+# securityadmin.sh: OpenSearch가 완전히 준비된 직후에도 일시적으로 거부할 수 있음 — 최대 5회 재시도
+SEC_OK=false
+for i in $(seq 1 5); do
+  if /opt/opensearch/plugins/opensearch-security/tools/securityadmin.sh \
+      -cd /opt/opensearch/config/opensearch-security/ \
+      -icl -nhnv \
+      -cacert /opt/opensearch/config/certs/root-ca.pem \
+      -cert  /opt/opensearch/config/certs/admin.pem \
+      -key   /opt/opensearch/config/certs/admin-key.pem \
+      -h localhost; then
+    log "OpenSearch security initialized (attempt $i)."
+    SEC_OK=true
+    break
+  fi
+  log "securityadmin.sh failed, retrying in 30s... ($i/5)"
+  sleep 30
+done
+if [ "$SEC_OK" = "false" ]; then
+  log "ERROR: Failed to initialize OpenSearch security after 5 attempts."
+  exit 1
+fi
 
 # 플러그인 설치: 한국어 형태소 분석기 + KNN + S3 스냅샷
-/opt/opensearch/bin/opensearch-plugin install --batch analysis-nori || true
-/opt/opensearch/bin/opensearch-plugin install --batch opensearch-knn || true
-/opt/opensearch/bin/opensearch-plugin install --batch repository-s3 || true
-systemctl restart opensearch
+# 이미 설치된 플러그인은 스킵 — EC2 재생성 시 매번 재설치되나, 동일 인스턴스 재실행 방어
+PLUGIN_LIST=$(/opt/opensearch/bin/opensearch-plugin list 2>/dev/null || echo "")
+PLUGINS_CHANGED=false
+for PLUGIN in analysis-nori opensearch-knn repository-s3; do
+  if echo "$PLUGIN_LIST" | grep -q "$PLUGIN"; then
+    log "Plugin $PLUGIN already installed, skipping."
+  else
+    /opt/opensearch/bin/opensearch-plugin install --batch "$PLUGIN" || true
+    PLUGINS_CHANGED=true
+  fi
+done
+if [ "$PLUGINS_CHANGED" = "true" ]; then
+  systemctl restart opensearch
+fi
 
 # ---- 7. OpenSearch API 서비스 설치 ----
 log "Installing OpenSearch API server..."
 mkdir -p "$OPENSEARCH_API_DIR"
-# venv는 EBS(/data)에 생성 — 루트 디스크(20GB) 용량 부족 방지
-python3.11 -m venv "$DATA_MOUNT/opensearch-api-venv"
-# CPU-only torch + transformers 4.x 사전 설치
-# - torch: CPU 버전으로 CUDA 2GB 다운로드 방지
-# - transformers==4.41.0: 5.x 설치 시 sentence-transformers와 torch._dynamo 충돌 방지
-"$DATA_MOUNT/opensearch-api-venv/bin/pip" install -q --upgrade pip
-"$DATA_MOUNT/opensearch-api-venv/bin/pip" install -q torch --index-url https://download.pytorch.org/whl/cpu
-"$DATA_MOUNT/opensearch-api-venv/bin/pip" install -q "transformers==4.41.0"
+# venv는 EBS(/data)에 생성 — EC2 재생성(루트 디스크 초기화) 후에도 EBS는 보존됨
+# torch(~300MB) + transformers(~150MB) 재다운로드 방지
+if [ -f "$DATA_MOUNT/opensearch-api-venv/bin/python" ]; then
+  log "EBS venv already exists, skipping torch/transformers install."
+else
+  log "Creating venv and installing torch + transformers..."
+  python3.11 -m venv "$DATA_MOUNT/opensearch-api-venv"
+  # CPU-only torch: CUDA 2GB 다운로드 방지
+  # transformers==4.41.0: 5.x에서 sentence-transformers와 torch._dynamo 충돌
+  "$DATA_MOUNT/opensearch-api-venv/bin/pip" install -q --upgrade pip
+  "$DATA_MOUNT/opensearch-api-venv/bin/pip" install -q torch --index-url https://download.pytorch.org/whl/cpu
+  "$DATA_MOUNT/opensearch-api-venv/bin/pip" install -q "transformers==4.41.0"
+fi
 chown -R ubuntu:ubuntu "$OPENSEARCH_API_DIR" "$DATA_MOUNT/opensearch-api-venv"
 
 # ---- 8. OpenSearch API systemd 서비스 등록 ----

--- a/opensearch/create_snapshot.sh
+++ b/opensearch/create_snapshot.sh
@@ -8,26 +8,38 @@ REGION="ap-northeast-2"
 REPO_NAME="s3_backup"
 SNAPSHOT_NAME="opensearch_snapshot"
 
+# opensearch-api.service 에서 관리자 패스워드 추출
+OS_PASSWORD=$(grep -Po 'OPENSEARCH_ADMIN_PASSWORD=\K[^ \n]+' \
+  /etc/systemd/system/opensearch-api.service 2>/dev/null | head -1 || true)
+if [ -z "$OS_PASSWORD" ]; then
+  echo "ERROR: OPENSEARCH_ADMIN_PASSWORD를 서비스 파일에서 찾을 수 없습니다."
+  exit 1
+fi
+
+BASE_URL="https://localhost:9200"
+CURL_AUTH="-u admin:$OS_PASSWORD"
+CURL_TLS="-k"
+
 # S3 스냅샷 repository 등록
 echo "Registering S3 snapshot repository..."
-curl -sf -X PUT "http://localhost:9200/_snapshot/$REPO_NAME" \
+curl -sf $CURL_TLS $CURL_AUTH -X PUT "$BASE_URL/_snapshot/$REPO_NAME" \
   -H "Content-Type: application/json" \
   -d "{\"type\":\"s3\",\"settings\":{\"bucket\":\"$BUCKET\",\"base_path\":\"opensearch-snapshots\",\"region\":\"$REGION\"}}"
 echo ""
 
 # 인덱스 상태 확인
 echo "현재 인덱스 상태:"
-curl -s "http://localhost:9200/_cat/indices?h=index,docs.count,health" | grep product
+curl -s $CURL_TLS $CURL_AUTH "$BASE_URL/_cat/indices?h=index,docs.count,health" | grep product
 
 # 기존 스냅샷 삭제
 echo "기존 스냅샷 삭제 중..."
-curl -s -X DELETE "http://localhost:9200/_snapshot/$REPO_NAME/$SNAPSHOT_NAME" || true
+curl -s $CURL_TLS $CURL_AUTH -X DELETE "$BASE_URL/_snapshot/$REPO_NAME/$SNAPSHOT_NAME" || true
 sleep 3
 
 # 새 스냅샷 생성 (전체 product 인덱스 포함, 완료까지 대기)
 echo "스냅샷 생성 중: $SNAPSHOT_NAME (수 분 소요)"
-curl -sf -X PUT \
-  "http://localhost:9200/_snapshot/$REPO_NAME/$SNAPSHOT_NAME?wait_for_completion=true" \
+curl -sf $CURL_TLS $CURL_AUTH -X PUT \
+  "$BASE_URL/_snapshot/$REPO_NAME/$SNAPSHOT_NAME?wait_for_completion=true" \
   -H "Content-Type: application/json" \
   -d '{"indices": "product_*", "ignore_unavailable": true, "include_global_state": false}'
 

--- a/opensearch/index_forbidden_sentences.py
+++ b/opensearch/index_forbidden_sentences.py
@@ -33,6 +33,8 @@ if _DIR not in sys.path:
 from path_utils import get_absolute_path
 
 INDEX_NAME = "forbidden_sentences"
+# 로컬 개발 기준 경로 — EC2에서는 FORBIDDEN_KEYWORD_JSON_PATH 환경변수가 이 값을 덮어씀
+# (opensearch-api.service: Environment=FORBIDDEN_KEYWORD_JSON_PATH=/opt/opensearch-api/data/forbidden_keyword.json)
 DEFAULT_JSON_PATH = get_absolute_path(
     "backend", "app", "agents", "generate_message_agent", "data", "forbidden_keyword.json"
 )

--- a/opensearch/restore_or_skip.sh
+++ b/opensearch/restore_or_skip.sh
@@ -8,15 +8,29 @@ REGION="ap-northeast-2"
 REPO_NAME="s3_backup"
 SNAPSHOT_NAME="opensearch_snapshot"
 
+# opensearch-api.service 에서 관리자 패스워드 추출
+# SSM 실행 환경에는 OPENSEARCH_ADMIN_PASSWORD가 없으므로 서비스 파일에서 읽음
+OS_PASSWORD=$(grep -Po 'OPENSEARCH_ADMIN_PASSWORD=\K[^ \n]+' \
+  /etc/systemd/system/opensearch-api.service 2>/dev/null | head -1 || true)
+if [ -z "$OS_PASSWORD" ]; then
+  echo "ERROR: OPENSEARCH_ADMIN_PASSWORD를 서비스 파일에서 찾을 수 없습니다."
+  exit 1
+fi
+
+# OpenSearch는 TLS가 활성화된 HTTPS 전용 — -k로 자체 서명 인증서 허용
+BASE_URL="https://localhost:9200"
+CURL_AUTH="-u admin:$OS_PASSWORD"
+CURL_TLS="-k"
+
 # S3 스냅샷 repository 등록 (멱등 — 매번 실행해도 안전)
 echo "Registering S3 snapshot repository..."
-curl -sf -X PUT "http://localhost:9200/_snapshot/$REPO_NAME" \
+curl -sf $CURL_TLS $CURL_AUTH -X PUT "$BASE_URL/_snapshot/$REPO_NAME" \
   -H "Content-Type: application/json" \
   -d "{\"type\":\"s3\",\"settings\":{\"bucket\":\"$BUCKET\",\"base_path\":\"opensearch-snapshots\",\"region\":\"$REGION\"}}"
 echo ""
 
 # 인덱스에 데이터가 있는지 확인
-COUNT=$(curl -s "http://localhost:9200/product_index_v3/_count" 2>/dev/null \
+COUNT=$(curl -s $CURL_TLS $CURL_AUTH "$BASE_URL/product_index_v3/_count" 2>/dev/null \
   | python3 -c "import sys,json; print(json.load(sys.stdin).get('count', 0))" 2>/dev/null \
   || echo 0)
 
@@ -30,7 +44,7 @@ fi
 echo "인덱스가 비어있습니다. S3 스냅샷 확인 중..."
 
 # S3 스냅샷 존재 여부 확인
-SNAP_COUNT=$(curl -s "http://localhost:9200/_snapshot/$REPO_NAME/$SNAPSHOT_NAME" 2>/dev/null \
+SNAP_COUNT=$(curl -s $CURL_TLS $CURL_AUTH "$BASE_URL/_snapshot/$REPO_NAME/$SNAPSHOT_NAME" 2>/dev/null \
   | python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d.get('snapshots', [])))" 2>/dev/null \
   || echo 0)
 
@@ -42,15 +56,15 @@ fi
 echo "S3 스냅샷 복원 시작: $SNAPSHOT_NAME"
 
 # 기존 product 인덱스 삭제 (복원 전 클린업)
-curl -s -X DELETE "http://localhost:9200/product_*" || true
+curl -s $CURL_TLS $CURL_AUTH -X DELETE "$BASE_URL/product_*" || true
 sleep 2
 
 # 스냅샷 복원 (글로벌 상태 제외, product 인덱스만)
-curl -sf -X POST \
-  "http://localhost:9200/_snapshot/$REPO_NAME/$SNAPSHOT_NAME/_restore?wait_for_completion=true" \
+curl -sf $CURL_TLS $CURL_AUTH -X POST \
+  "$BASE_URL/_snapshot/$REPO_NAME/$SNAPSHOT_NAME/_restore?wait_for_completion=true" \
   -H "Content-Type: application/json" \
   -d '{"ignore_unavailable": true, "include_global_state": false}'
 
 echo ""
 echo "스냅샷 복원 완료."
-curl -s "http://localhost:9200/_cat/indices?h=index,docs.count,health" | grep product
+curl -s $CURL_TLS $CURL_AUTH "$BASE_URL/_cat/indices?h=index,docs.count,health" | grep product


### PR DESCRIPTION
problem
- GitHub Actions 배포 시 OpenSearch EC2 user_data가 30분 내에 완료되지 않아 "did not complete within 30 minutes" 오류로 배포 파이프라인이 반복 실패함
- restore_or_skip.sh / create_snapshot.sh가 OpenSearch에 plain HTTP로 요청하여 TLS 핸드셰이크 오류로 즉시 종료, SSM 커맨드 "Failed" → deploy step exit 1

as is
- user_data 스크립트가 apt-get upgrade 시 Ubuntu 최초 부팅 unattended-upgrades의 dpkg lock과 충돌 → set -euo pipefail로 스크립트 전체 즉사, /var/log/user-data-complete 미생성 → 60번 내내 WAIT
- OpenSearch 2.13.0 tarball(~600MB)을 artifacts.opensearch.org(외부 인터넷)에서 매 EC2 재생성마다 다운로드, torch(~300MB) + transformers(~150MB)도 재설치
- OpenSearch 기동 대기 상한 120초 → t3.medium JVM 콜드 스타트(60~150초)에 부족, 타임아웃 후 securityadmin.sh 실행 시 연결 거부 → set -e 즉사
- restore_or_skip.sh: http://localhost:9200 사용 + 인증 없음, SSM 환경에 OPENSEARCH_ADMIN_PASSWORD 미존재

to be
- apt-get 전에 unattended-upgrades 서비스 중지 + dpkg lock 해제 최대 5분 대기
- OpenSearch tarball을 S3에 최초 1회 캐시(deploy.yml package-data-services), 이후 배포는 VPC Gateway Endpoint 경유 S3에서 다운로드(NAT 우회, 무료)
- EBS(/data)에 venv 존재 시 torch/transformers 재설치 스킵 (EC2 재생성 후에도 EBS는 보존되므로 ~450MB 절감)
- OpenSearch 기동 대기 300초(60×5s)로 연장, 미기동 시 명시적 exit 1
- securityadmin.sh 최대 5회 재시도(30초 간격)
- restore_or_skip.sh / create_snapshot.sh: https + -k(자체 서명 인증서), opensearch-api.service에서 패스워드 추출하여 인증
- 워크플로우 OpenSearch 폴링 타임아웃 30분 → 40분으로 확장