### PR TITLE
fix: OpenSearch EC2 user_data 40분 타임아웃 개선

### DIFF
--- a/infra/ec2/user_data/opensearch_setup.sh
+++ b/infra/ec2/user_data/opensearch_setup.sh
@@ -16,6 +16,7 @@ OPENSEARCH_API_DIR="/opt/opensearch-api"
 DATA_MOUNT="/data"
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a /var/log/user-data.log; }
+trap 'log "FAILED at line $LINENO (exit $?)"' ERR
 
 # ---- 1. 시스템 업데이트 ----
 log "Waiting for apt lock..."
@@ -32,7 +33,6 @@ done
 log "Updating system packages..."
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -qq
-apt-get upgrade -y -qq
 apt-get install -y -qq gnupg openjdk-17-jdk python3.11 python3.11-venv python3-pip git
 
 # ---- 2. EBS 데이터 볼륨 마운트 ----


### PR DESCRIPTION
problem:
- GitHub Actions "Wait for OpenSearch EC2 user_data" 단계가 80회(40분) 폴링 후 항상 타임아웃

as is:
- apt-get upgrade로 전체 패키지 업그레이드 수행 (10~15분 소요)
- 스크립트 중간 실패 시 어느 단계에서 죽었는지 로그에 남지 않음
- 전체 설치 소요 시간이 구조적으로 40분을 초과

to be:
- apt-get upgrade 제거로 약 10~15분 절감
- ERR trap 추가로 실패 시 /var/log/user-data.log에 실패 라인·exit code 기록