### PR TITLE
fix: OpenSearch EC2 user_data 타임아웃 근본 원인 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -304,6 +304,7 @@ jobs:
               "/usr/local/bin/aws s3 cp s3://${{ env.PROJECT_NAME }}-deploy/data.tar.gz /tmp/data.tar.gz",
               "mkdir -p /opt/data && tar -xzf /tmp/data.tar.gz -C /opt/",
               "chmod +x /opt/opensearch-api/restore_or_skip.sh /opt/opensearch-api/create_snapshot.sh",
+              "for i in $(seq 1 60); do [ -f /var/log/venv-ready ] && break; echo \"Waiting for venv ($i/60)...\"; sleep 30; done; [ -f /var/log/venv-ready ] || { echo ERROR: venv not ready; exit 1; }",
               "/data/opensearch-api-venv/bin/pip install -q -r /opt/opensearch-api/requirements.txt",
               "chown -R ubuntu:ubuntu /opt/opensearch-api",
               "systemctl restart opensearch-api"

--- a/infra/ec2/user_data/opensearch_setup.sh
+++ b/infra/ec2/user_data/opensearch_setup.sh
@@ -52,7 +52,13 @@ if ! blkid "$DATA_DISK" &>/dev/null; then
   mkfs.ext4 -F "$DATA_DISK"
 fi
 mkdir -p "$DATA_MOUNT"
-mount "$DATA_DISK" "$DATA_MOUNT" || true
+if ! mountpoint -q "$DATA_MOUNT"; then
+  mount "$DATA_DISK" "$DATA_MOUNT"
+fi
+if ! mountpoint -q "$DATA_MOUNT"; then
+  log "ERROR: Failed to mount $DATA_DISK to $DATA_MOUNT"
+  exit 1
+fi
 grep -q "$DATA_DISK" /etc/fstab || echo "$DATA_DISK $DATA_MOUNT ext4 defaults,nofail 0 2" >> /etc/fstab
 
 # ---- 3. 스왑 파일 ----
@@ -282,7 +288,7 @@ Environment=OPENSEARCH_USE_SSL=true
 Environment=OPENSEARCH_ADMIN_PASSWORD=$OPENSEARCH_ADMIN_PASSWORD
 Environment=INTERNAL_TOKEN=$INTERNAL_TOKEN
 Environment=FORBIDDEN_KEYWORD_JSON_PATH=/opt/opensearch-api/data/forbidden_keyword.json
-ExecStartPre=/bin/sleep 60
+ExecStartPre=/bin/bash -c 'for i in $(seq 1 60); do [ -f /var/log/venv-ready ] && exit 0; echo "Waiting for venv ($i/60)..."; sleep 30; done; exit 1'
 ExecStart=$DATA_MOUNT/opensearch-api-venv/bin/uvicorn opensearch_api:app --host 0.0.0.0 --port 8010 --workers 1
 Restart=always
 RestartSec=5
@@ -298,6 +304,26 @@ UNIT
 
 systemctl daemon-reload
 systemctl enable opensearch-api
+
+# ---- 9. venv/torch 백그라운드 설치 ----
+# torch CPU 설치는 15~30분 소요. CI 대기를 막지 않도록 백그라운드 실행.
+# opensearch-api.service는 /var/log/venv-ready를 확인한 뒤 기동됨.
+if [ -f "$DATA_MOUNT/opensearch-api-venv/bin/python" ]; then
+  log "EBS venv exists, skipping torch/transformers install."
+  touch /var/log/venv-ready
+else
+  log "Starting background venv install (torch ~20min)..."
+  (
+    python3.11 -m venv "$DATA_MOUNT/opensearch-api-venv"
+    "$DATA_MOUNT/opensearch-api-venv/bin/pip" install -q --upgrade pip
+    "$DATA_MOUNT/opensearch-api-venv/bin/pip" install -q torch --index-url https://download.pytorch.org/whl/cpu
+    "$DATA_MOUNT/opensearch-api-venv/bin/pip" install -q "transformers==4.41.0"
+    chown -R ubuntu:ubuntu "$DATA_MOUNT/opensearch-api-venv"
+    log "Background venv install complete."
+    touch /var/log/venv-ready
+  ) >> /var/log/user-data.log 2>&1 &
+fi
+chown -R ubuntu:ubuntu "$OPENSEARCH_API_DIR" 2>/dev/null || true
 
 log "OpenSearch setup complete."
 touch /var/log/user-data-complete


### PR DESCRIPTION
problem:
- "Wait for OpenSearch EC2 user_data" 폴링이 80회(40분) 내내 WAIT 후 타임아웃
- apt-get upgrade 제거로도 해결되지 않음

as is:
- mount 실패 시 || true로 조용히 무시 → torch가 임시 루트 FS에 설치됨
- EC2 교체(user_data_replace_on_change) 시 루트 FS 초기화 → EBS venv 캐시가 단 한 번도 작동하지 않음
- torch 설치 이후에만 user-data-complete 생성 → torch 15~30분 + 나머지 20분 = 구조적 40분 초과

to be:
- mountpoint -q 로 마운트 성공 여부를 명시적으로 검증, 실패 시 exit 1
- user-data-complete를 torch 설치 이전에 생성 (OpenSearch + 서비스 등록 완료 기준)
- torch는 백그라운드 서브셸로 실행, 완료 시 /var/log/venv-ready 마커 생성
- opensearch-api.service ExecStartPre에서 venv-ready 대기 (최대 30분)
- deploy SSM 커맨드에서도 pip install 전 venv-ready 대기