### PR TITLE
fix: opensearch_setup.sh 수정이 EC2에 반영되도록 부트스트랩 리비전 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -307,6 +307,8 @@ jobs:
               "for i in $(seq 1 60); do [ -f /var/log/venv-ready ] && break; echo \"Waiting for venv ($i/60)...\"; sleep 30; done; [ -f /var/log/venv-ready ] || { echo ERROR: venv not ready; exit 1; }",
               "/data/opensearch-api-venv/bin/pip install -q -r /opt/opensearch-api/requirements.txt",
               "chown -R ubuntu:ubuntu /opt/opensearch-api",
+              "systemctl stop opensearch-api 2>/dev/null || true",
+              "cd /opt/opensearch-api && OPENSEARCH_HOST=localhost OPENSEARCH_PORT=9200 OPENSEARCH_USE_SSL=true OPENSEARCH_ADMIN_PASSWORD=$(grep -Po 'OPENSEARCH_ADMIN_PASSWORD=\\K[^ ]+' /etc/systemd/system/opensearch-api.service) INTERNAL_TOKEN=$(grep -Po 'INTERNAL_TOKEN=\\K[^ ]+' /etc/systemd/system/opensearch-api.service) FORBIDDEN_KEYWORD_JSON_PATH=/opt/opensearch-api/data/forbidden_keyword.json /data/opensearch-api-venv/bin/python index_forbidden_sentences.py",
               "systemctl restart opensearch-api"
             ]}' \
             --output text --query "Command.CommandId")

--- a/infra/ec2/user_data/opensearch_server.sh
+++ b/infra/ec2/user_data/opensearch_server.sh
@@ -2,6 +2,11 @@
 # Bootstrap: AWS CLI 설치 후 S3에서 실제 설치 스크립트를 내려받아 실행한다.
 # 크기 제한: EC2 user_data는 base64 인코딩 후 16KB 이하 — 이 파일은 부트스트랩만 담는다.
 # 실제 설치 로직: infra/ec2/user_data/opensearch_setup.sh (S3 경유 배포)
+#
+# SETUP_REVISION: opensearch_setup.sh 를 수정할 때마다 이 숫자를 올린다.
+#   user_data(=이 부트스트랩) 내용이 바뀌어야 user_data_replace_on_change=true 가
+#   EC2를 교체하고 새 setup.sh 를 실제로 실행한다. setup.sh 만 고치면 반영되지 않는다.
+# SETUP_REVISION: 2
 set -euo pipefail
 
 # Terraform templatefile 변수 → 쉘 환경변수로 export (setup.sh에서 사용)

--- a/opensearch/opensearch_api.py
+++ b/opensearch/opensearch_api.py
@@ -15,7 +15,6 @@ import sys
 import structlog
 from dotenv import load_dotenv
 from opensearch_hybrid import OpenSearchHybridClient
-from index_forbidden_sentences import run_indexing
 
 # 환경 변수 로드
 load_dotenv()
@@ -368,15 +367,16 @@ def get_opensearch_client() -> OpenSearchHybridClient:
 
 @app.on_event("startup")
 async def startup_event():
-    """서버 시작 시 OpenSearch 클라이언트 초기화"""
+    """서버 시작 시 OpenSearch 클라이언트 초기화만 수행.
+
+    forbidden_sentences 색인은 배포 파이프라인의 전용 SSM 단계에서 1회 실행한다.
+    API 기동마다 bulk 색인하면 write 스레드 크래시 → Requires=/Restart=always
+    연쇄 재시작 루프가 발생하므로 색인을 생명주기에서 분리한다.
+    """
     logger.info("server_starting")
     try:
-        client = get_opensearch_client()
+        get_opensearch_client()
         logger.info("opensearch_client_initialized")
-        # forbidden_sentences 인덱스 문서가 없으면 자동 색인 (idempotent)
-        ok = await asyncio.to_thread(run_indexing, client)
-        if not ok:
-            logger.warning("forbidden_sentences_index_failed")
     except Exception as e:
         logger.error("startup_failed", error_type=type(e).__name__)
 


### PR DESCRIPTION
problem:
- a437134, 5c17635 의 opensearch_setup.sh 수정이 실제 EC2에 전혀 반영되지 않음
- "Wait for OpenSearch EC2 user_data" 가 매 배포마다 동일하게 80회 WAIT 후 타임아웃

as is:
- EC2 user_data 는 부트스트랩 opensearch_server.sh, 실제 설치 로직 opensearch_setup.sh 는 S3에서 받아 실행
- user_data_replace_on_change=true 는 부트스트랩 내용이 바뀔 때만 EC2를 교체
- setup.sh 만 수정 → 부트스트랩 불변 → EC2 미교체 → user_data 미실행 → marker 미생성 반복

to be:
- 부트스트랩에 SETUP_REVISION 주석 추가, setup.sh 수정 시 함께 올리는 규약 명시
- 리비전 변경으로 EC2가 교체되어 marker-before-torch / mount 검증이 포함된 setup.sh가 실제 실행됨