### PR TITLE
fix: OpenSearch 보안 도구 실행 권한 누락으로 user_data 실패 해결

### DIFF
--- a/infra/ec2/user_data/opensearch_server.sh
+++ b/infra/ec2/user_data/opensearch_server.sh
@@ -6,7 +6,7 @@
 # SETUP_REVISION: opensearch_setup.sh 를 수정할 때마다 이 숫자를 올린다.
 #   user_data(=이 부트스트랩) 내용이 바뀌어야 user_data_replace_on_change=true 가
 #   EC2를 교체하고 새 setup.sh 를 실제로 실행한다. setup.sh 만 고치면 반영되지 않는다.
-# SETUP_REVISION: 2
+# SETUP_REVISION: 3
 set -euo pipefail
 
 # Terraform templatefile 변수 → 쉘 환경변수로 export (setup.sh에서 사용)

--- a/infra/ec2/user_data/opensearch_setup.sh
+++ b/infra/ec2/user_data/opensearch_setup.sh
@@ -209,6 +209,9 @@ fi
 
 # ---- 보안 플러그인 초기화 ----
 log "Initializing OpenSearch security..."
+# OpenSearch 2.13 tarball의 보안 도구(hash.sh, securityadmin.sh)는 실행 권한 없이(0644)
+# 배포된다. 직접 실행하면 exit 126으로 죽으므로 +x 부여 후 사용한다.
+chmod +x /opt/opensearch/plugins/opensearch-security/tools/*.sh
 HASHED_PW=$(/opt/opensearch/plugins/opensearch-security/tools/hash.sh \
   -p "$OPENSEARCH_ADMIN_PASSWORD" | tail -1)
 INTERNAL_USERS="/opt/opensearch/config/opensearch-security/internal_users.yml"


### PR DESCRIPTION
problem:
- EC2 교체 후에도 "Wait for OpenSearch EC2 user_data"가 marker 미생성으로 계속 WAIT
- 실제 인스턴스 로그(ERR trap)에서 확인: "FAILED at line 213 (exit 126)"

root cause
- OpenSearch 2.13 tarball의 보안 도구 hash.sh / securityadmin.sh는 실행 권한 없이(0644) 배포됨
- setup.sh가 이를 bash 없이 /opt/.../hash.sh 로 직접 실행 → exit 126(실행 불가) → set -e 로 스크립트 즉사 → /var/log/user-data-complete 미생성
- 그동안 ERR trap이 없어 보이지 않던 진짜 블로커였음 (journal의 admin 401은 보안 초기화 전 readiness curl이 내는 정상 응답으로 무관)

as is:
- chmod 없이 hash.sh 직접 실행 → 보안 초기화 단계에서 항상 실패

to be:
- 보안 초기화 직전 chmod +x .../opensearch-security/tools/*.sh 로 hash.sh, securityadmin.sh 실행 권한 부여
- setup.sh 변경이 EC2에 반영되도록 부트스트랩 SETUP_REVISION 2 → 3