### PR TITLE
fix: EC2 부트스트랩이 낡은 setup.sh를 받는 race 제거 — 내용 해시 버전 키화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,6 +92,18 @@ jobs:
         working-directory: infra/ec2
         run: terraform init
 
+      # setup.sh를 내용 해시로 버전 키화해 apply 전에 S3 업로드.
+      # EC2 부트스트랩이 이 해시 키만 받으므로 낡은 setup.sh를 받는 race가 사라진다.
+      # (S3 버킷은 기존 인프라에 이미 존재. 최초 배포 시엔 package job이 동일 키를 재업로드)
+      - name: Upload versioned opensearch_setup.sh to S3
+        id: setup-hash
+        run: |
+          HASH=$(sha256sum infra/ec2/user_data/opensearch_setup.sh | cut -c1-16)
+          echo "hash=$HASH" >> $GITHUB_OUTPUT
+          aws s3 cp infra/ec2/user_data/opensearch_setup.sh \
+            "s3://${PROJECT_NAME}-deploy/opensearch_setup.${HASH}.sh" \
+            || echo "bucket not ready (first deploy) — package job will upload"
+
       - name: Terraform Apply
         working-directory: infra/ec2
         run: terraform apply -auto-approve
@@ -101,6 +113,7 @@ jobs:
           TF_VAR_environment:   production
           TF_VAR_ecr_registry:  "${{ steps.account.outputs.id }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com"
           TF_VAR_ecr_image_tag: ${{ github.sha }}
+          TF_VAR_opensearch_setup_hash: ${{ steps.setup-hash.outputs.hash }}
 
           # ── 시크릿 (GitHub Secrets에서 주입) ──
           TF_VAR_opensearch_admin_password: ${{ secrets.OPENSEARCH_ADMIN_PASSWORD }}
@@ -151,10 +164,11 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Upload opensearch_setup.sh to S3
+      - name: Upload versioned opensearch_setup.sh to S3 (first-deploy safety net)
         run: |
+          HASH=$(sha256sum infra/ec2/user_data/opensearch_setup.sh | cut -c1-16)
           aws s3 cp infra/ec2/user_data/opensearch_setup.sh \
-            s3://${{ env.PROJECT_NAME }}-deploy/opensearch_setup.sh
+            "s3://${{ env.PROJECT_NAME }}-deploy/opensearch_setup.${HASH}.sh"
 
       - name: Cache OpenSearch tarball in S3 (skip if already uploaded)
         run: |

--- a/infra/ec2/ec2.tf
+++ b/infra/ec2/ec2.tf
@@ -131,6 +131,7 @@ resource "aws_instance" "opensearch" {
     OPENSEARCH_VERSION        = "2.13.0"
     internal_token            = var.internal_token
     opensearch_admin_password = var.opensearch_admin_password
+    setup_hash                = var.opensearch_setup_hash
   }))
 
   root_block_device {

--- a/infra/ec2/user_data/opensearch_server.sh
+++ b/infra/ec2/user_data/opensearch_server.sh
@@ -3,10 +3,11 @@
 # 크기 제한: EC2 user_data는 base64 인코딩 후 16KB 이하 — 이 파일은 부트스트랩만 담는다.
 # 실제 설치 로직: infra/ec2/user_data/opensearch_setup.sh (S3 경유 배포)
 #
-# SETUP_REVISION: opensearch_setup.sh 를 수정할 때마다 이 숫자를 올린다.
-#   user_data(=이 부트스트랩) 내용이 바뀌어야 user_data_replace_on_change=true 가
-#   EC2를 교체하고 새 setup.sh 를 실제로 실행한다. setup.sh 만 고치면 반영되지 않는다.
-# SETUP_REVISION: 3
+# setup.sh는 내용 해시로 버전 키화된다: s3://.../opensearch_setup.<setup_hash>.sh
+#   - CI가 sha256으로 해시를 계산해 S3 업로드 + Terraform var로 주입
+#   - 이 부트스트랩이 해시 키만 받으므로 이전 배포의 낡은 setup.sh를 받는 race가 없다
+#   - setup.sh가 바뀌면 해시→user_data 변경→EC2 자동 교체 (수동 리비전 관리 불필요)
+SETUP_HASH="${setup_hash}"
 set -euo pipefail
 
 # Terraform templatefile 변수 → 쉘 환경변수로 export (setup.sh에서 사용)
@@ -28,12 +29,13 @@ unzip -q /tmp/awscliv2.zip -d /tmp
 rm -rf /tmp/awscliv2.zip /tmp/aws
 log "Bootstrap: AWS CLI installed."
 
-# package-data-services job이 opensearch_setup.sh를 S3에 올릴 때까지 대기 (최대 20분)
-log "Bootstrap: waiting for opensearch_setup.sh in S3..."
+# 해시 키 setup.sh를 S3에서 대기 (terraform apply 전 CI가 업로드, 최대 20분)
+SETUP_KEY="opensearch_setup.$SETUP_HASH.sh"
+log "Bootstrap: waiting for $SETUP_KEY in S3..."
 SETUP_READY=false
 for i in $(seq 1 20); do
   if /usr/local/bin/aws s3 cp \
-      "s3://$PROJECT_NAME-deploy/opensearch_setup.sh" \
+      "s3://$PROJECT_NAME-deploy/$SETUP_KEY" \
       /tmp/opensearch_setup.sh 2>/dev/null; then
     log "Bootstrap: setup script downloaded (attempt $i)."
     SETUP_READY=true
@@ -44,7 +46,7 @@ for i in $(seq 1 20); do
 done
 
 if [ "$SETUP_READY" = "false" ]; then
-  log "ERROR: opensearch_setup.sh not found in S3 after 20 minutes."
+  log "ERROR: $SETUP_KEY not found in S3 after 20 minutes."
   exit 1
 fi
 

--- a/infra/ec2/variables.tf
+++ b/infra/ec2/variables.tf
@@ -16,6 +16,17 @@ variable "project_name" {
   default     = "ai-innovation"
 }
 
+variable "opensearch_setup_hash" {
+  description = <<-EOT
+    opensearch_setup.sh 내용 해시. CI가 sha256으로 계산해 주입한다.
+    S3 키(opensearch_setup.<hash>.sh)와 부트스트랩 user_data에 함께 들어가므로
+    setup.sh가 바뀌면 EC2가 자동 교체되고, 부트스트랩은 정확히 그 버전만 내려받는다.
+    (S3 latest 키를 받던 race condition 제거 + 수동 SETUP_REVISION 불필요)
+  EOT
+  type        = string
+  default     = "dev"
+}
+
 # ---- 네트워크 ----
 
 variable "vpc_cidr" {


### PR DESCRIPTION
problem:
- chmod 수정(577ae37)을 배포했는데도 user_data가 동일하게 hash.sh exit 126으로 실패
- 인스턴스 로그 분석: setup.sh 다운로드 08:30:46 vs 새 버전 S3 업로드 08:30:50 → 새 EC2가 새 setup.sh 업로드 4초 전에 이전 배포의 낡은 setup.sh를 받음

root cause
- 부트스트랩이 고정 키 s3://.../opensearch_setup.sh 를 즉시 다운로드
- 이 키는 이전 배포부터 이미 존재 → "S3 대기" 루프가 낡은 버전으로 즉시 통과
- 새 버전 업로드(package job)는 terraform 이후라 EC2 부팅보다 늦음
- 결과: setup.sh를 아무리 고치고 EC2를 교체해도 매번 직전 버전이 실행됨

as is:
- 고정 키 + latest-wins 업로드 → 전달 보장 없음 + 수동 SETUP_REVISION 의존

to be:
- setup.sh를 sha256 해시로 버전 키화: opensearch_setup.<hash>.sh
- CI가 terraform apply 전에 해시 키로 업로드하고 TF_VAR로 해시 주입
- 부트스트랩은 해시 키만 다운로드 → 낡은 버전을 받을 경로 없음 (race 제거)
- setup.sh 변경 시 해시→user_data 변경→EC2 자동 교체 (수동 리비전 불필요)
- package job은 동일 해시 키 재업로드로 최초 배포 안전망 유지