### PR TITLE
fix: 플러그인을 OpenSearch 시작 전 설치 — RED 클러스터로 인한 보안 초기화 무한 대기 해결

### DIFF
--- a/infra/ec2/user_data/opensearch_setup.sh
+++ b/infra/ec2/user_data/opensearch_setup.sh
@@ -159,6 +159,22 @@ sed -i 's/-Xmx[0-9]*[gGmM]/-Xmx1000m/g' /opt/opensearch/config/jvm.options
 grep -q "Xms" /opt/opensearch/config/jvm.options || echo "-Xms1000m" >> /opt/opensearch/config/jvm.options
 grep -q "Xmx" /opt/opensearch/config/jvm.options || echo "-Xmx1000m" >> /opt/opensearch/config/jvm.options
 
+# ---- 플러그인 설치 (반드시 OpenSearch 시작 전) ----
+# 보존 EBS의 product_v4_* 인덱스는 korean_analyzer(nori_tokenizer)에 의존한다.
+# 시작 시점에 nori가 없으면 샤드 복구가 IllegalArgumentException으로 실패 → 클러스터 RED
+# → securityadmin이 cluster state 조회에서 타임아웃 무한 반복 → user_data 미완료.
+# OpenSearch가 죽어있는 상태에서 오프라인 설치하므로 재시작이 필요 없다.
+log "Installing plugins (before startup)..."
+PLUGIN_LIST=$(/opt/opensearch/bin/opensearch-plugin list 2>/dev/null || echo "")
+for PLUGIN in analysis-nori opensearch-knn repository-s3; do
+  if echo "$PLUGIN_LIST" | grep -q "$PLUGIN"; then
+    log "Plugin $PLUGIN already installed, skipping."
+  else
+    /opt/opensearch/bin/opensearch-plugin install --batch "$PLUGIN" || true
+  fi
+done
+chown -R opensearch:opensearch /opt/opensearch/plugins
+
 # ---- 6. OpenSearch systemd 서비스 ----
 log "Registering opensearch service..."
 cat > /etc/systemd/system/opensearch.service <<'UNIT'
@@ -237,21 +253,6 @@ done
 if [ "$SEC_OK" = "false" ]; then
   log "ERROR: Failed to initialize OpenSearch security after 5 attempts."
   exit 1
-fi
-
-# ---- 플러그인 설치 ----
-PLUGIN_LIST=$(/opt/opensearch/bin/opensearch-plugin list 2>/dev/null || echo "")
-PLUGINS_CHANGED=false
-for PLUGIN in analysis-nori opensearch-knn repository-s3; do
-  if echo "$PLUGIN_LIST" | grep -q "$PLUGIN"; then
-    log "Plugin $PLUGIN already installed, skipping."
-  else
-    /opt/opensearch/bin/opensearch-plugin install --batch "$PLUGIN" || true
-    PLUGINS_CHANGED=true
-  fi
-done
-if [ "$PLUGINS_CHANGED" = "true" ]; then
-  systemctl restart opensearch
 fi
 
 # ---- 7. OpenSearch API venv ----


### PR DESCRIPTION
problem:
- chmod 수정 후 securityadmin 단계 도달했으나 "cluster state 30s timeout" 무한 반복
- 인스턴스 진단: 클러스터 status=red, product_v4_* 샤드 14개 unassigned
- OpenSearch 로그: "Custom Analyzer [korean_analyzer] failed to find tokenizer under name [nori_tokenizer]" → 영속 인덱스 복구 실패

root cause:
- 보존 EBS의 product_v4_* 인덱스는 korean_analyzer(nori_tokenizer)에 의존
- setup.sh가 OpenSearch를 먼저 시작한 뒤(인덱스 복구 시도) 플러그인을 나중에 설치
- 시작 시점에 analysis-nori가 없어 샤드 복구가 실패 → 클러스터 RED
- securityadmin은 RED 클러스터에서 cluster state 조회가 타임아웃 → user_data 미완료
- 그동안 앞 단계(hash.sh)에서 죽어 이 문제가 가려져 있었음

as is:
- 순서: OpenSearch 시작 → 보안 초기화 → 플러그인 설치(+조건부 재시작)

to be:
- 순서: 플러그인 오프라인 설치(시작 전) → OpenSearch 시작 → 보안 초기화
- 시작 시 nori 등 플러그인이 이미 존재 → 영속 인덱스 정상 복구 → YELLOW → securityadmin 통과 → marker 생성
- OpenSearch 미기동 상태 오프라인 설치이므로 재시작 로직 제거