### PR TITLE
fix: forbidden 색인 SSM 명령의 따옴표 충돌 — 스크립트 파일로 분리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -317,12 +317,12 @@ jobs:
               "tar -xzf /tmp/opensearch.tar.gz -C /opt/opensearch-api",
               "/usr/local/bin/aws s3 cp s3://${{ env.PROJECT_NAME }}-deploy/data.tar.gz /tmp/data.tar.gz",
               "mkdir -p /opt/data && tar -xzf /tmp/data.tar.gz -C /opt/",
-              "chmod +x /opt/opensearch-api/restore_or_skip.sh /opt/opensearch-api/create_snapshot.sh",
+              "chmod +x /opt/opensearch-api/restore_or_skip.sh /opt/opensearch-api/create_snapshot.sh /opt/opensearch-api/index_forbidden.sh",
               "for i in $(seq 1 60); do [ -f /var/log/venv-ready ] && break; echo \"Waiting for venv ($i/60)...\"; sleep 30; done; [ -f /var/log/venv-ready ] || { echo ERROR: venv not ready; exit 1; }",
               "/data/opensearch-api-venv/bin/pip install -q -r /opt/opensearch-api/requirements.txt",
               "chown -R ubuntu:ubuntu /opt/opensearch-api",
               "systemctl stop opensearch-api 2>/dev/null || true",
-              "cd /opt/opensearch-api && OPENSEARCH_HOST=localhost OPENSEARCH_PORT=9200 OPENSEARCH_USE_SSL=true OPENSEARCH_ADMIN_PASSWORD=$(grep -Po 'OPENSEARCH_ADMIN_PASSWORD=\\K[^ ]+' /etc/systemd/system/opensearch-api.service) INTERNAL_TOKEN=$(grep -Po 'INTERNAL_TOKEN=\\K[^ ]+' /etc/systemd/system/opensearch-api.service) FORBIDDEN_KEYWORD_JSON_PATH=/opt/opensearch-api/data/forbidden_keyword.json /data/opensearch-api-venv/bin/python index_forbidden_sentences.py",
+              "/opt/opensearch-api/index_forbidden.sh",
               "systemctl restart opensearch-api"
             ]}' \
             --output text --query "Command.CommandId")

--- a/opensearch/index_forbidden.sh
+++ b/opensearch/index_forbidden.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# forbidden_sentences 색인 one-shot (배포 SSM 단계에서 호출).
+# opensearch-api.service에서 자격증명을 추출해 venv python으로 색인한다.
+# index_forbidden_sentences.py는 count>0면 스킵하는 idempotent 구조.
+# 인라인 SSM 명령의 작은따옴표 충돌을 피하려고 별도 스크립트로 분리 (restore_or_skip.sh와 동일 패턴).
+set -eu
+
+SVC=/etc/systemd/system/opensearch-api.service
+
+OS_PW=$(grep -Po 'OPENSEARCH_ADMIN_PASSWORD=\K[^ ]+' "$SVC" | head -1)
+if [ -z "$OS_PW" ]; then
+  echo "ERROR: OPENSEARCH_ADMIN_PASSWORD를 서비스 파일에서 찾을 수 없습니다."
+  exit 1
+fi
+
+export OPENSEARCH_HOST=localhost
+export OPENSEARCH_PORT=9200
+export OPENSEARCH_USE_SSL=true
+export OPENSEARCH_ADMIN_PASSWORD="$OS_PW"
+export FORBIDDEN_KEYWORD_JSON_PATH=/opt/opensearch-api/data/forbidden_keyword.json
+
+cd /opt/opensearch-api
+/data/opensearch-api-venv/bin/python index_forbidden_sentences.py


### PR DESCRIPTION
problem:
- "Deploy to OpenSearch EC2 via SSM" 단계가 aws CLI param 검증 실패로 exit 252
- 인라인 명령의 grep -Po '...' 작은따옴표가 --parameters '{...}' 바깥 따옴표를 깨뜨림
- (이 단계 도달 자체가 user_data mount/플러그인/보안/marker 정상 완료를 의미)

as is:
- SSM commands 배열에 grep -Po '패턴' 을 인라인으로 삽입 → 따옴표 중첩 충돌

to be:
- 색인 로직을 opensearch/index_forbidden.sh 로 분리 (restore_or_skip.sh와 동일 패턴)
  - 서비스 파일에서 OPENSEARCH_ADMIN_PASSWORD 추출, venv python으로 색인 (idempotent)
- SSM 명령은 /opt/opensearch-api/index_forbidden.sh 호출만 → 인라인 따옴표 제거
- chmod +x 대상에 index_forbidden.sh 추가