### PR TITLE
fix: OpenSearch EC2를 t3.large로 — KURE 색인 중 OOM으로 OpenSearch 다운 해결

### DIFF
--- a/infra/ec2/variables.tf
+++ b/infra/ec2/variables.tf
@@ -62,9 +62,14 @@ variable "db_instance_type" {
 }
 
 variable "opensearch_instance_type" {
-  description = "OpenSearch EC2 인스턴스 타입"
+  description = <<-EOT
+    OpenSearch EC2 인스턴스 타입. t3.large(8GB) 필요.
+    이 박스는 OpenSearch JVM(~1.5GB RSS) + opensearch-api 검색 서빙용 KURE-v1(~1.5GB)을
+    상주시키며(정상 운영 ~3GB), 배포 시 forbidden 색인이 추가 KURE를 로드한다.
+    t3.medium(4GB)은 색인 _bulk 스파이크에서 OOM으로 OpenSearch가 죽는다.
+  EOT
   type        = string
-  default     = "t3.medium"
+  default     = "t3.large"
 }
 
 variable "ec2_ami" {


### PR DESCRIPTION
problem:
- forbidden 색인이 KURE 임베딩 후 _bulk 던지는 순간 OpenSearch 연결 끊김→거부
- 진단: OOM. OpenSearch+OS만으로 used 1497MB/avail 2119MB(of 3863), KURE 1.5GB + _bulk refresh 스파이크가 4GB 한계 초과 → OpenSearch 프로세스 다운(Restart=always 재기동)

root cause:
- 이 박스는 OpenSearch JVM(~1.5GB) + opensearch-api 서빙용 KURE-v1(~1.5GB)을 상주 (정상 운영만으로 ~3GB) + 배포 시 색인이 추가 KURE 로드 → t3.medium(4GB) 초과
- t3.medium 회귀(40d4355)는 startup 색인 루프 대응이었고 용량 문제는 아니었음

as is:
- opensearch_instance_type = t3.medium (4GB)

to be:
- opensearch_instance_type = t3.large (8GB)
- 색인 중 ~4GB/8GB, 정상 서빙 ~3.5GB/8GB로 헤드룸 확보
- instance_type 변경이 인스턴스 교체를 유발 → 새 인스턴스가 fsck·복구·색인 정상 수행