### PR TITLE
fix: forbidden_sentences knn_vector를 lucene 엔진으로 + 인스턴스 t3.medium 환원

### DIFF
--- a/infra/ec2/variables.tf
+++ b/infra/ec2/variables.tf
@@ -63,13 +63,13 @@ variable "db_instance_type" {
 
 variable "opensearch_instance_type" {
   description = <<-EOT
-    OpenSearch EC2 인스턴스 타입. t3.large(8GB) 필요.
-    이 박스는 OpenSearch JVM(~1.5GB RSS) + opensearch-api 검색 서빙용 KURE-v1(~1.5GB)을
-    상주시키며(정상 운영 ~3GB), 배포 시 forbidden 색인이 추가 KURE를 로드한다.
-    t3.medium(4GB)은 색인 _bulk 스파이크에서 OOM으로 OpenSearch가 죽는다.
+    OpenSearch EC2 인스턴스 타입.
+    OpenSearch JVM(~1.5GB) + opensearch-api 서빙용 KURE-v1(~1.5GB) ≈ 3GB 상주.
+    forbidden 색인 one-shot은 opensearch-api를 정지한 뒤 실행하므로 t3.medium(4GB)+swap로 충분.
+    (과거 색인 크래시는 메모리가 아니라 knn nmslib 네이티브 미탑재 문제였고 lucene 엔진으로 해결됨)
   EOT
   type        = string
-  default     = "t3.large"
+  default     = "t3.medium"
 }
 
 variable "ec2_ami" {

--- a/opensearch/index_forbidden_sentences.py
+++ b/opensearch/index_forbidden_sentences.py
@@ -56,6 +56,16 @@ def _build_mapping(vector_dim: int) -> dict:
                 "sentence_vector": {
                     "type": "knn_vector",
                     "dimension": vector_dim,
+                    # 엔진 미지정 시 기본 nmslib(네이티브 JNI)로 생성되는데, 해당 네이티브
+                    # 라이브러리(opensearchknn_nmslib) 미탑재 환경에서는 색인 시 write 스레드가
+                    # UnsatisfiedLinkError로 fatal 크래시 → OpenSearch 다운.
+                    # product_v4_* 인덱스와 동일하게 lucene 엔진(순수 Java)으로 고정한다.
+                    "method": {
+                        "name": "hnsw",
+                        "space_type": "cosinesimil",
+                        "engine": "lucene",
+                        "parameters": {"ef_construction": 128, "m": 16},
+                    },
                 },
             }
         },
@@ -102,8 +112,16 @@ def run_indexing(client=None, force: bool = False) -> bool:
             logger.error("OpenSearch 연결 실패")
             return False
 
-    if force:
-        client.delete_index(INDEX_NAME)
+    # 기존 인덱스가 비어있으면(0 docs) 매핑 변경(nmslib→lucene 엔진)을 반영하기 위해
+    # 삭제 후 재생성한다. 이미 문서가 있으면(정상 매핑으로 색인 완료) 그대로 둔다.
+    try:
+        if force or (
+            client.client.indices.exists(index=INDEX_NAME)
+            and client.client.count(index=INDEX_NAME)["count"] == 0
+        ):
+            client.delete_index(INDEX_NAME)
+    except Exception:
+        pass
 
     vector_dim = len(client.model.encode("dummy"))
     mapping = _build_mapping(vector_dim)


### PR DESCRIPTION
problem:
- forbidden 색인 _bulk 시 OpenSearch가 write 스레드 fatal error로 다운 (t3.large에서도 동일)
- 서버 로그: java.lang.UnsatisfiedLinkError: no opensearchknn_nmslib in java.library.path
- 메모리 6GB 여유 → OOM 아님 (직전 t3.large 변경의 OOM 가정은 오판)

root cause:
- forbidden_sentences의 knn_vector가 method 미지정 → 기본 nmslib(네이티브 JNI) 엔진
- 네이티브 라이브러리 미탑재 환경에서 색인 시 UnsatisfiedLinkError → write 스레드 JVM 종료
- 정상 동작하는 product_v4_*는 engine: lucene(순수 Java) 사용 — forbidden만 누락

to be:
- knn_vector에 method{ name: hnsw, space_type: cosinesimil, engine: lucene } 명시 (product_v4와 동일)
- 기존 빈(0 docs) nmslib 인덱스는 run_indexing에서 자동 삭제·재생성하여 새 매핑 반영
- 색인 크래시가 메모리 무관임이 확인되어 opensearch_instance_type을 t3.medium으로 환원