### PR TITLE
fix: CRM chat/v2 400 오류 — InternalTokenMiddleware BaseHTTPMiddleware …

### DIFF
--- a/backend/app/core/internal_auth.py
+++ b/backend/app/core/internal_auth.py
@@ -1,18 +1,50 @@
 import hmac
+import json
 
-from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from ..config.settings import settings
 
 _SKIP_PATHS = {"/", "/health", "/ready"}
 
+_UNAUTHORIZED_BODY = json.dumps({"detail": "Unauthorized"}).encode()
+_UNAUTHORIZED_HEADERS = [
+    (b"content-type", b"application/json"),
+    (b"content-length", str(len(_UNAUTHORIZED_BODY)).encode()),
+]
 
-class InternalTokenMiddleware(BaseHTTPMiddleware):
-    async def dispatch(self, request, call_next):
-        if request.url.path in _SKIP_PATHS:
-            return await call_next(request)
-        token = request.headers.get("X-Internal-Token", "")
+
+class InternalTokenMiddleware:
+    """X-Internal-Token 헤더 검증 — pure ASGI middleware.
+
+    BaseHTTPMiddleware 대신 pure ASGI로 구현한다:
+    BaseHTTPMiddleware 두 개가 중첩되면 anyio receive 채널이 끊겨
+    route handler에서 request.body()가 b""을 반환하는 Starlette 버그 회피.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        if path in _SKIP_PATHS:
+            await self.app(scope, receive, send)
+            return
+
+        headers = dict(scope.get("headers", []))
+        token = headers.get(b"x-internal-token", b"").decode("latin-1")
+
         if not settings.internal_token or not hmac.compare_digest(token, settings.internal_token):
-            return JSONResponse({"detail": "Unauthorized"}, status_code=401)
-        return await call_next(request)
+            await send({
+                "type": "http.response.start",
+                "status": 401,
+                "headers": _UNAUTHORIZED_HEADERS,
+            })
+            await send({"type": "http.response.body", "body": _UNAUTHORIZED_BODY})
+            return
+
+        await self.app(scope, receive, send)


### PR DESCRIPTION
…중첩으로 인한 request body 소실 수정

problem:
CRM 서비스의 POST /api/marketing/chat/v2 엔드포인트가 모든 요청에서 400 "There was an error parsing the body"를 반환하여 E2E 채팅이 전혀 동작하지 않음

as is:
InternalTokenMiddleware가 BaseHTTPMiddleware로 구현되어, RequestLoggingMiddleware(BaseHTTPMiddleware)와 중첩된 상태. Starlette는 BaseHTTPMiddleware.call_next() 내부에서 anyio task group + memory channel 쌍을 생성해 receive를 전달하는데, 두 개가 중첩되면 inner middleware의 receive stream이 outer의 channel에 올바르게 연결되지 않음. 결과적으로 route handler에서 await request.body()가 b""을 반환하고, request.json() → json.loads(b"") → JSONDecodeError → 400 응답

to be:
InternalTokenMiddleware를 pure ASGI middleware(__call__(scope, receive, send))로 재구현. receive를 변경 없이 그대로 다음 레이어로 전달하므로 body stream 소실 없음. X-Internal-Token 헤더 검증 로직은 동일하게 유지, 실패 시 ASGI 응답을 직접 write하여 401 반환