### PR TITLE
fix: RequestLoggingMiddleware·InternalTokenMiddleware BaseHTTPMiddlew…

### DIFF
--- a/backend/app/core/middleware.py
+++ b/backend/app/core/middleware.py
@@ -7,11 +7,8 @@ contextvars를 통해 전체 에이전트 실행 과정에 전파됩니다.
 
 import re
 import time
-from typing import Callable
 
-from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.requests import Request
-from starlette.responses import Response
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 from .context import generate_request_id, set_request_id
 from .logging import get_logger
@@ -22,18 +19,25 @@ _REQUEST_ID_RE = re.compile(r'^[a-zA-Z0-9\-]{1,64}$')
 logger = get_logger("http")
 
 
-class RequestLoggingMiddleware(BaseHTTPMiddleware):
-    """
-    미들웨어 기능:
-    1. 요청마다 고유한 request_id 생성
-    2. contextvars에 설정 (모든 하위 로그에 자동 전파)
-    3. 요청 시작 및 응답 완료를 소요 시간과 함께 로깅
-    4. 응답 헤더에 X-Request-ID 추가
+class RequestLoggingMiddleware:
+    """요청/응답 로깅 — pure ASGI middleware.
+
+    BaseHTTPMiddleware 대신 pure ASGI로 구현한다:
+    BaseHTTPMiddleware.call_next()는 anyio task group + memory channel을 생성해
+    receive를 전달하는데, 중첩 시 body stream이 끊기는 Starlette 버그 회피.
     """
 
-    async def dispatch(self, request: Request, call_next: Callable) -> Response:
-        # 클라이언트 제공 X-Request-ID는 형식 검증 후 신뢰, 미통과 시 서버 생성값 사용
-        client_request_id = request.headers.get("X-Request-ID", "")
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        # request_id 생성
+        headers = dict(scope.get("headers", []))
+        client_request_id = headers.get(b"x-request-id", b"").decode("latin-1")
         request_id = (
             client_request_id
             if client_request_id and _REQUEST_ID_RE.match(client_request_id)
@@ -41,13 +45,10 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         )
         set_request_id(request_id)
 
-        # 엔드포인트에서 접근할 수 있도록 request.state에 저장
-        request.state.request_id = request_id
-
-        # 요청 메타데이터 추출
-        method = request.method
-        path = request.url.path
-        client_host = request.client.host if request.client else "unknown"
+        method = scope.get("method", "")
+        path = scope.get("path", "")
+        client = scope.get("client")
+        client_host = client[0] if client else "unknown"
 
         logger.info(
             "request_started",
@@ -57,26 +58,24 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
         )
 
         start_time = time.perf_counter()
+        status_code = 500
 
+        async def send_wrapper(message: dict) -> None:
+            nonlocal status_code
+            if message["type"] == "http.response.start":
+                status_code = message["status"]
+                # X-Request-ID 응답 헤더 추가
+                headers_list = list(message.get("headers", []))
+                headers_list.append((b"x-request-id", request_id.encode()))
+                message = {**message, "headers": headers_list}
+            await send(message)
+
+        failed = False
         try:
-            response = await call_next(request)
-            duration_ms = (time.perf_counter() - start_time) * 1000
-
-            logger.info(
-                "request_completed",
-                method=method,
-                path=path,
-                status_code=response.status_code,
-                duration_ms=round(duration_ms, 1),
-            )
-
-            # 응답에 상관관계 헤더 추가
-            response.headers["X-Request-ID"] = request_id
-            return response
-
+            await self.app(scope, receive, send_wrapper)
         except Exception as e:
+            failed = True
             duration_ms = (time.perf_counter() - start_time) * 1000
-
             logger.error(
                 "request_failed",
                 method=method,
@@ -85,3 +84,13 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
                 error_type=type(e).__name__,
             )
             raise
+
+        if not failed:
+            duration_ms = (time.perf_counter() - start_time) * 1000
+            logger.info(
+                "request_completed",
+                method=method,
+                path=path,
+                status_code=status_code,
+                duration_ms=round(duration_ms, 1),
+            )


### PR DESCRIPTION
…are → pure ASGI 전환으로 request body 소실 수정

problem:
CRM POST /api/marketing/chat/v2 및 게이트웨이 경유 모든 JSON POST 요청이 400 "There was an error parsing the body" 반환, E2E 채팅 완전 불동작

as is:
RequestLoggingMiddleware(gateway·crm 공용)와 InternalTokenMiddleware(crm)가 모두 BaseHTTPMiddleware로 구현됨. BaseHTTPMiddleware.call_next()는 내부적으로 anyio memory channel 쌍을 생성해 receive를 전달하는데, 두 개가 중첩되면 inner의 receive stream이 outer task group 생명주기에 묶여 body chunk가 소실됨. 결과적으로 route handler에서 await request.body() → b"", json.loads(b"") → JSONDecodeError → 400

to be:
RequestLoggingMiddleware, InternalTokenMiddleware 모두 pure ASGI middleware(__call__(scope, receive, send))로 재구현. receive를 변경 없이 다음 레이어로 그대로 전달하므로 body stream 소실 없음. 각 미들웨어의 기존 로직(request_id 생성·로깅, X-Internal-Token 검증)은 동일하게 유지