### PR TITLE
fix: DLM lifecycle policy description를 ASCII로 변경 — AWS 유효성 검증 오류 해결

### DIFF
--- a/infra/ec2/backup.tf
+++ b/infra/ec2/backup.tf
@@ -32,7 +32,7 @@ resource "aws_iam_role_policy_attachment" "dlm" {
 # ---- DLM 라이프사이클 정책 — 데이터 EBS 볼륨 일일 스냅샷 ----
 
 resource "aws_dlm_lifecycle_policy" "ebs_daily" {
-  description        = "${var.project_name} 데이터 볼륨 일일 EBS 스냅샷 (DB + OpenSearch)"
+  description        = "${var.project_name} daily EBS snapshots - DB and OpenSearch data volumes"
   execution_role_arn = aws_iam_role.dlm.arn
   state              = "ENABLED"
 


### PR DESCRIPTION
problem:
terraform apply 시 aws_dlm_lifecycle_policy.ebs_daily에서 Error: invalid value for description 발생

as is:
DLM 정책 description에 한글·괄호 포함: "${var.project_name} 데이터 볼륨 일일 EBS 스냅샷 (DB + OpenSearch)" → AWS DLM description은 [0-9A-Za-z _-]만 허용하므로 거부됨

to be:
ASCII 영숫자·공백·하이픈만 사용: "${var.project_name} daily EBS snapshots - DB and OpenSearch data volumes" → terraform validate 통과, apply 정상 진행