### PR TITLE
fix: 빈 API 키 시크릿 생성 오류 해결 — openai/anthropic 시크릿 조건부 생성

### DIFF
--- a/infra/ec2/ecs.tf
+++ b/infra/ec2/ecs.tf
@@ -146,14 +146,21 @@ locals {
   ]
 
   # 민감 환경변수 — Secrets Manager에서 valueFrom으로 주입 (모든 서비스 공통)
-  common_secrets = [
-    { name = "POSTGRES_URL", valueFrom = aws_secretsmanager_secret.postgres_url.arn },
-    { name = "POSTGRES_PASSWORD", valueFrom = aws_secretsmanager_secret.postgres_password.arn },
-    { name = "INTERNAL_TOKEN", valueFrom = aws_secretsmanager_secret.internal_token.arn },
-    { name = "JWT_SECRET", valueFrom = aws_secretsmanager_secret.jwt_secret.arn },
-    { name = "OPENAI_API_KEY", valueFrom = aws_secretsmanager_secret.openai_api_key.arn },
-    { name = "ANTHROPIC_API_KEY", valueFrom = aws_secretsmanager_secret.anthropic_api_key.arn },
-  ]
+  # API 키는 설정된 것만 주입 (빈 키는 시크릿 미생성 → 여기서도 제외)
+  common_secrets = concat(
+    [
+      { name = "POSTGRES_URL", valueFrom = aws_secretsmanager_secret.postgres_url.arn },
+      { name = "POSTGRES_PASSWORD", valueFrom = aws_secretsmanager_secret.postgres_password.arn },
+      { name = "INTERNAL_TOKEN", valueFrom = aws_secretsmanager_secret.internal_token.arn },
+      { name = "JWT_SECRET", valueFrom = aws_secretsmanager_secret.jwt_secret.arn },
+    ],
+    var.openai_api_key != "" ? [
+      { name = "OPENAI_API_KEY", valueFrom = aws_secretsmanager_secret.openai_api_key[0].arn },
+    ] : [],
+    var.anthropic_api_key != "" ? [
+      { name = "ANTHROPIC_API_KEY", valueFrom = aws_secretsmanager_secret.anthropic_api_key[0].arn },
+    ] : [],
+  )
 
   # A2A 서비스 URL — Cloud Map DNS 이름
   a2a_env = [

--- a/infra/ec2/secrets.tf
+++ b/infra/ec2/secrets.tf
@@ -108,24 +108,30 @@ resource "aws_secretsmanager_secret_version" "jwt_secret" {
   secret_string = var.jwt_secret
 }
 
+# API 키는 사용하는 모델에 따라 한쪽만 설정됨(gpt면 openai, claude면 anthropic).
+# 빈 값은 Secrets Manager가 거부하므로 값이 있을 때만 시크릿 생성.
 resource "aws_secretsmanager_secret" "openai_api_key" {
+  count                   = var.openai_api_key != "" ? 1 : 0
   name                    = "${var.project_name}/openai-api-key"
   description             = "OPENAI_API_KEY for ECS tasks"
   recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "openai_api_key" {
-  secret_id     = aws_secretsmanager_secret.openai_api_key.id
+  count         = var.openai_api_key != "" ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.openai_api_key[0].id
   secret_string = var.openai_api_key
 }
 
 resource "aws_secretsmanager_secret" "anthropic_api_key" {
+  count                   = var.anthropic_api_key != "" ? 1 : 0
   name                    = "${var.project_name}/anthropic-api-key"
   description             = "ANTHROPIC_API_KEY for ECS tasks"
   recovery_window_in_days = 0
 }
 
 resource "aws_secretsmanager_secret_version" "anthropic_api_key" {
-  secret_id     = aws_secretsmanager_secret.anthropic_api_key.id
+  count         = var.anthropic_api_key != "" ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.anthropic_api_key[0].id
   secret_string = var.anthropic_api_key
 }


### PR DESCRIPTION
problem:
terraform apply가 aws_secretsmanager_secret_version.anthropic_api_key에서 실패 — InvalidRequestException: You must provide either SecretString or SecretBinary

as is:
gpt 모델만 사용해 ANTHROPIC_API_KEY GitHub Secret이 비어 있는데, secret_version이 빈 문자열로 생성을 시도 → Secrets Manager가 빈 값 거부

to be:
- secrets.tf: openai/anthropic 시크릿과 version에 count = var.xxx_api_key != "" ? 1 : 0 적용 — 값이 있을 때만 생성
- ecs.tf: common_secrets를 concat으로 재구성 — 설정된 API 키만 ECS에 주입