### PR TITLE
fix: 빈 API 키 시크릿 오류 + DB 데이터 유실 버그 수정

### DIFF
--- a/infra/ec2/user_data/db_server.sh
+++ b/infra/ec2/user_data/db_server.sh
@@ -56,10 +56,19 @@ apt-get update -qq
 apt-get install -y -qq postgresql-15
 
 # PostgreSQL 데이터 디렉터리를 EBS 볼륨으로 이동
+# 데이터 볼륨에 기존 클러스터가 있으면 절대 덮어쓰지 않는다.
+#    (과거: 매 부팅마다 신규 빈 클러스터를 rsync로 덮어써 EC2 교체 시 데이터 유실)
 systemctl stop postgresql || true
-mkdir -p "$DATA_MOUNT/postgresql/15/main"
-if [ -d /var/lib/postgresql/15/main ] && [ "$(ls -A /var/lib/postgresql/15/main)" ]; then
-  rsync -a /var/lib/postgresql/ "$DATA_MOUNT/postgresql/"
+if [ -f "$DATA_MOUNT/postgresql/15/main/PG_VERSION" ]; then
+  # 기존 클러스터 보존 — rsync 금지 (EC2 교체 시 데이터 유지)
+  log "Existing PostgreSQL cluster found on data volume — preserving (no rsync)."
+else
+  # 최초 초기화에만 신규 설치본을 데이터 볼륨으로 복사
+  log "No existing cluster on data volume — initializing from fresh install."
+  mkdir -p "$DATA_MOUNT/postgresql/15/main"
+  if [ -d /var/lib/postgresql/15/main ] && [ "$(ls -A /var/lib/postgresql/15/main)" ]; then
+    rsync -a /var/lib/postgresql/ "$DATA_MOUNT/postgresql/"
+  fi
 fi
 chown -R postgres:postgres "$DATA_MOUNT/postgresql"
 sed -i "s|/var/lib/postgresql|$DATA_MOUNT/postgresql|g" /etc/postgresql/15/main/postgresql.conf


### PR DESCRIPTION
problem:
- terraform apply가 aws_secretsmanager_secret_version.anthropic_api_key에서 실패 — InvalidRequestException: You must provide either SecretString or SecretBinary
- EC2 교체 시마다 PostgreSQL 데이터가 사라지고 0건으로 보임

as is:
- gpt 모델만 사용해 ANTHROPIC_API_KEY GitHub Secret이 비어 있는데, 시크릿 version이 빈 문자열로 생성을 시도 → Secrets Manager가 빈 값 거부
- db_server.sh가 부팅 때마다 apt가 만든 신규 빈 클러스터를 rsync -a로 기존 데이터 EBS 위에 무조건 덮어씀 → 카탈로그가 빈 클러스터로 교체되어 기존 데이터가 orphan으로 밀려남

to be:
- secrets.tf: openai/anthropic 시크릿과 version에 count = var.xxx_api_key != "" ? 1 : 0 적용 — 값이 있을 때만 생성. ecs.tf: common_secrets를 concat으로 재구성해 설정된 API 키만 ECS에 주입
- db_server.sh: 데이터 볼륨에 기존 클러스터($DATA_MOUNT/postgresql/15/main/PG_VERSION)가 있으면 rsync를 건너뛰고 보존, 최초 초기화에만 신규 설치본 복사