### PR TITLE
fix: OpenSearch 색인 실패 시 DB 고아 레코드 발생 — 재시도 + 보상 트랜잭션으로 정합성 보장

### DIFF
--- a/backend/app/agents/data_registration_agent/services/product_registration.py
+++ b/backend/app/agents/data_registration_agent/services/product_registration.py
@@ -573,26 +573,75 @@ class ProductRegistrationService:
             r.raise_for_status()
             logger.info("register_product_db_done", product_name=product_name, product_id=product_id)
 
-            # 5. OpenSearch 색인 → vectordb_id 수집
+            # 5. OpenSearch 색인 → vectordb_id 수집 (재시도 + 보상 트랜잭션 포함)
             logger.info(
                 "register_product_opensearch_start",
                 product_name=product_name,
                 product_id=product_id,
                 group=group,
             )
-            r = await self.http_client.post(
-                f"{settings.opensearch_api_url}/api/product/index-multivector",
-                json={
-                    "product_id": product_id,
-                    "group":      group,
-                    "multivector": multivector,
-                },
-                timeout=settings.http_timeout_upload,
-            )
-            r.raise_for_status()
-            index_result = r.json()
-            if not index_result.get("success", False):
-                raise RuntimeError("OpenSearch 색인 실패")
+            last_os_exc: Exception | None = None
+            index_result: dict = {}
+            for attempt in range(settings.opensearch_index_max_retries):
+                try:
+                    r = await self.http_client.post(
+                        f"{settings.opensearch_api_url}/api/product/index-multivector",
+                        json={
+                            "product_id": product_id,
+                            "group":      group,
+                            "multivector": multivector,
+                        },
+                        timeout=settings.http_timeout_upload,
+                    )
+                    r.raise_for_status()
+                    index_result = r.json()
+                    if not index_result.get("success", False):
+                        raise RuntimeError("OpenSearch 색인 실패")
+                    last_os_exc = None
+                    break
+                except Exception as os_exc:
+                    last_os_exc = os_exc
+                    logger.warning(
+                        "register_product_opensearch_retry",
+                        product_id=product_id,
+                        attempt=attempt + 1,
+                        max_retries=settings.opensearch_index_max_retries,
+                        error_type=type(os_exc).__name__,
+                    )
+                    if attempt < settings.opensearch_index_max_retries - 1:
+                        await asyncio.sleep(
+                            min(settings.a2a_retry_backoff_base ** attempt, settings.a2a_retry_backoff_max)
+                        )
+
+            if last_os_exc is not None:
+                logger.error(
+                    "register_product_opensearch_all_retries_exhausted",
+                    product_id=product_id,
+                    max_retries=settings.opensearch_index_max_retries,
+                    error_type=type(last_os_exc).__name__,
+                )
+                # 보상: step 4에서 커밋된 DB row 삭제 (고아 레코드 방지)
+                try:
+                    comp_headers: dict[str, str] = {}
+                    if user_id:
+                        comp_headers["X-User-Assertion"] = self._make_user_assertion(user_id)
+                    comp_r = await self.http_client.request(
+                        "DELETE",
+                        f"{settings.database_api_url}/api/products",
+                        json={"ids": [product_id]},
+                        headers=comp_headers,
+                        timeout=settings.http_timeout_default,
+                    )
+                    comp_r.raise_for_status()
+                    logger.info("register_product_db_compensated", product_id=product_id)
+                except Exception as comp_exc:
+                    logger.error(
+                        "register_product_compensation_failed",
+                        product_id=product_id,
+                        error_type=type(comp_exc).__name__,
+                    )
+                raise last_os_exc
+
             vectordb_id = index_result.get("vectordb_id", {})
             logger.info("register_product_opensearch_done", product_name=product_name, product_id=product_id)
 

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -247,6 +247,9 @@ class Settings(BaseSettings):
     a2a_retry_backoff_base: float = 2.0
     a2a_retry_backoff_max: float = 30.0
 
+    # OpenSearch 색인 재시도 (backoff은 a2a_retry_backoff_base/max 재사용)
+    opensearch_index_max_retries: int = Field(default=3, ge=1)
+
     # LLM temperatures (역할별)
     llm_temperature_classifier: float = 0.0
     llm_temperature_generator: float = 0.7


### PR DESCRIPTION
problem:
상품 등록 파이프라인(step 4 DB INSERT → step 5 OpenSearch 색인)에서 step 5가 실패하면 step 4의 DB 커밋은 이미 완료된 상태로 남는다. 보상 로직이 없어 DB에는 상품이 존재하지만 OpenSearch에는 벡터가 없는 고아 레코드가 생성되며, 벡터 기반 추천이 해당 상품에 대해 동작하지 않는다. 또한 OpenSearch 색인 실패에 재시도가 없어 일시적 네트워크 장애만으로도 상품이 누락된다.

as is:
- step 5 OpenSearch 색인 실패 시 RuntimeError가 상위 except로 전파되고, step 4의 DB row는 보상 없이 그대로 커밋 상태로 잔존
- 재시도 없음 — 일시적 장애도 즉시 실패 처리

to be:
- settings.py: opensearch_index_max_retries(기본 3) 추가 — A2A retry와 독립적으로 튜닝 가능
- product_registration.py step 5를 Retry + Compensating Saga로 교체
  - 재시도 먼저: OpenSearch 색인은 doc_id 고정 + index operation(upsert)으로 idempotent하므로 최대 3회 지수 백오프(base 2.0s, max 30s)로 안전하게 재시도
  - 보상 트랜잭션: 3회 모두 실패 시 DELETE /api/products(ids=[product_id])로 step 4 커밋 롤백, 고아 레코드 방지. 보상 실패 시 register_product_compensation_failed 로그로 추적
  - 기존 배치 루프 에러 집계 경로({"success": False}) 변경 없음