### PR TITLE
fix: 컨테이너에서 category.json 경로 불일치로 상품 등록 실패

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,7 +14,7 @@ RUN uv pip install --system --no-cache -r /requirements.txt
 WORKDIR /app
 # 앱 코드 — ECS는 볼륨 마운트가 없으므로 이미지에 포함되어야 함 (.dockerignore가 .env/캐시 제외)
 COPY backend/ /app/
-COPY data/category.json /app/data/category.json
+COPY data/category.json /data/category.json
 
 # 비루트 유저로 실행 (보안)
 RUN useradd --create-home --uid 10001 appuser && chown -R appuser:appuser /app


### PR DESCRIPTION
problem:
Dockerfile이 data/category.json을 /app/data/category.json으로 복사했으나 category_config.py의 parents[5]는 컨테이너 루트(/)를 가리킴

as is:
코드 탐색 경로: /data/category.json
실제 파일 위치: /app/data/category.json
→ FileNotFoundError 발생, 모든 상품 업로드 잡이 succeeded:0 / failed:1로 종료

to be:
COPY 대상을 /data/category.json으로 변경해 코드가 기대하는 경로와 일치시킴