### PR TITLE
fix: 멀티벡터 문서 생성 타임아웃 누락 — llm_document_timeout 적용

### DIFF
--- a/backend/app/agents/data_registration_agent/services/product_registration.py
+++ b/backend/app/agents/data_registration_agent/services/product_registration.py
@@ -451,7 +451,7 @@ class ProductRegistrationService:
 
         for attempt in range(2):
             try:
-                response = await ainvoke_with_timeout(self._document_llm, [HumanMessage(content=prompt)])
+                response = await ainvoke_with_timeout(self._document_llm, [HumanMessage(content=prompt)], timeout=settings.llm_document_timeout)
             except Exception as e:
                 logger.error("generate_multivector_document_failed", main_category=main_category, group=group, attempt=attempt, error_type=type(e).__name__, exc_info=True)
                 raise


### PR DESCRIPTION
problem:
generate_multivector_document()가 ainvoke_with_timeout()에 타임아웃을 명시하지 않아 llm_call_timeout(70s) 기본값이 적용됨

as is:
_build_structured_document: llm_document_timeout(150s) 명시 → 성공 generate_multivector_document: 기본값 70s → TimeoutError로 상품 등록 실패

to be:
generate_multivector_document()에 timeout=settings.llm_document_timeout 명시, _build_structured_document와 동일한 150s 타임아웃 적용