### PR TITLE
fix: 상품 등록 LLM 타임아웃 — vision·문서 생성 전 단계 llm_document_timeout 통일

### DIFF
--- a/backend/app/agents/data_registration_agent/services/product_registration.py
+++ b/backend/app/agents/data_registration_agent/services/product_registration.py
@@ -149,7 +149,7 @@ async def _extract_text_from_chunks(
     })
 
     try:
-        response = await ainvoke_with_timeout(llm, [HumanMessage(content=image_content)])
+        response = await ainvoke_with_timeout(llm, [HumanMessage(content=image_content)], timeout=settings.llm_document_timeout)
     except Exception as e:
         logger.error("extract_text_from_chunks_failed", product_name=product_name, error_type=type(e).__name__, exc_info=True)
         raise
@@ -197,7 +197,7 @@ async def _extract_and_classify_from_chunks(
     })
 
     try:
-        response = await ainvoke_with_timeout(llm, [HumanMessage(content=image_content)])
+        response = await ainvoke_with_timeout(llm, [HumanMessage(content=image_content)], timeout=settings.llm_document_timeout)
     except Exception as e:
         logger.error("extract_and_classify_from_chunks_failed", product_name=product_name, error_type=type(e).__name__, exc_info=True)
         raise

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -165,7 +165,7 @@ class Settings(BaseSettings):
     # LLM call timeouts (seconds)
     llm_timeout: float = 60.0
     llm_call_timeout: float = 70.0
-    llm_document_timeout: float = 150.0
+    llm_document_timeout: float = 300.0
 
     # LangGraph
     langgraph_recursion_limit: int = 100


### PR DESCRIPTION
problem:
상품상세 이미지 3장 처리 시 vision LLM 및 멀티벡터 문서 생성 LLM이
llm_call_timeout(70s) 기본값을 사용해 TimeoutError로 상품 등록 실패

as is:
extract_text_from_chunks:          ainvoke_with_timeout 기본값 70s
extract_and_classify_from_chunks:  ainvoke_with_timeout 기본값 70s
generate_multivector_document:     ainvoke_with_timeout 기본값 70s
build_structured_document:         llm_document_timeout 150s (명시)
llm_document_timeout 설정값:       150s

to be:
위 세 함수 모두 timeout=settings.llm_document_timeout 명시 llm_document_timeout 설정값: 150s → 300s