### PR TITLE
fix: 상품 등록 LLM SDK 타임아웃 누락 — APITimeoutError 발생

### DIFF
--- a/backend/app/agents/data_registration_agent/services/product_registration.py
+++ b/backend/app/agents/data_registration_agent/services/product_registration.py
@@ -219,8 +219,8 @@ class ProductRegistrationService:
         self._image_http_client: httpx.AsyncClient | None = None
         register(self)
         model = settings.chatgpt_model_name
-        self._vision_llm   = get_llm(vision_model or model,   temperature=settings.llm_temperature_vision)
-        self._document_llm = get_llm(document_model or model, temperature=settings.llm_temperature_document)
+        self._vision_llm   = get_llm(vision_model or model,   temperature=settings.llm_temperature_vision,   timeout=settings.llm_registration_sdk_timeout)
+        self._document_llm = get_llm(document_model or model, temperature=settings.llm_temperature_document, timeout=settings.llm_registration_sdk_timeout)
 
     def _make_user_assertion(self, user_id: str) -> str:
         return create_user_assertion(

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -166,6 +166,7 @@ class Settings(BaseSettings):
     llm_timeout: float = 60.0
     llm_call_timeout: float = 70.0
     llm_document_timeout: float = 300.0
+    llm_registration_sdk_timeout: float = 330.0  # 상품 등록 LLM SDK 타임아웃 (llm_document_timeout보다 여유있게)
 
     # LangGraph
     langgraph_recursion_limit: int = 100


### PR DESCRIPTION
problem:
ProductRegistrationService의 vision/document LLM이 전역 llm_timeout(60s)으로 초기화되어 OpenAI SDK가 asyncio.wait_for(300s)보다 먼저 APITimeoutError 발생

as is:
ChatOpenAI(timeout=llm_timeout=60s) → SDK가 60s에 APITimeoutError asyncio.wait_for(llm_document_timeout=300s) → 도달 불가

to be:
llm_registration_sdk_timeout=330s 추가 (llm_document_timeout 300s보다 30s 여유) _vision_llm, _document_llm 생성 시 해당 타임아웃 개별 적용
전역 llm_timeout은 채팅/추천 에이전트에 영향 없음