### PR TITLE
fix: 상품 등록 LLM 타임아웃 계층 역전 — SDK timeout이 앱 wait_for보다 낮아 반복 실패

### DIFF
--- a/backend/app/core/llm_factory.py
+++ b/backend/app/core/llm_factory.py
@@ -69,17 +69,20 @@ def create_llm(model_name: str, temperature: float = 0, **kwargs) -> BaseChatMod
     Raises:
         ValueError: 지원하지 않는 모델명 접두사
     """
+    # 호출자가 timeout을 명시하면 그 값을 쓰고, 없으면 기본값 사용
+    kwargs.setdefault("timeout", settings.llm_timeout)
+
     if model_name.startswith(("gpt-", "o1", "o3", "o4")):
         from langchain_openai import ChatOpenAI
-        return ChatOpenAI(model=model_name, temperature=temperature, timeout=settings.llm_timeout, **kwargs)
+        return ChatOpenAI(model=model_name, temperature=temperature, **kwargs)
 
     elif model_name.startswith("claude-"):
         from langchain_anthropic import ChatAnthropic
-        return ChatAnthropic(model=model_name, temperature=temperature, timeout=settings.llm_timeout, **kwargs)
+        return ChatAnthropic(model=model_name, temperature=temperature, **kwargs)
 
     elif model_name.startswith("gemini-"):
         from langchain_google_genai import ChatGoogleGenerativeAI
-        return ChatGoogleGenerativeAI(model=model_name, temperature=temperature, timeout=settings.llm_timeout, **kwargs)
+        return ChatGoogleGenerativeAI(model=model_name, temperature=temperature, **kwargs)
 
     else:
         raise ValueError(


### PR DESCRIPTION
problem:
gpt-5-mini(추론 모델)의 구조화·멀티벡터 structured output 호출은 정상적으로도 60초를 넘기는데, OpenAI SDK 요청 timeout(llm_timeout=60s)이 앱의 asyncio.wait_for(llm_document_timeout)보다 안쪽에 있어 항상 먼저 발동

as is:
asyncio.wait_for(300s)            ← 앱 타임아웃 (바깥, 계속 올린 곳)
   └ ChatOpenAI(timeout=60s)      ← SDK 타임아웃 (안쪽, binding constraint)
→ 바깥 값을 올려도 무의미, 안쪽 60s가 먼저 APITimeoutError
→ SDK max_retries=2 재시도로 에러 타입이 asyncio.TimeoutError/APITimeoutError 혼재
→ 직전 수정은 timeout 중복 전달로 TypeError → 컨테이너 起動 실패 (배포 안 됨)

to be:
create_llm: kwargs.setdefault("timeout", llm_timeout)로 변경 → 호출자가 timeout을 덮어쓸 수 있게 하고 중복 전달 TypeError 제거
ProductRegistrationService의 vision/document LLM은
timeout=llm_registration_sdk_timeout(330s)로 생성
→ 계층 정상화: SDK(330s) > 앱 wait_for(300s)
채팅·추천 에이전트는 timeout 미지정으로 기존 60s 유지