### PR TITLE
fix: DB API 풀·스레드풀 용량 부족 — 동시 100건 요청 시 성공률 70%로 붕괴

### DIFF
--- a/database/.env.example
+++ b/database/.env.example
@@ -5,6 +5,11 @@ POSTGRES_DB=ai_innovation_db
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres123
 
+# SQLAlchemy 풀 + anyio 스레드풀 (Postgres max_connections 한도 내에서 관리자용 여유를 남기고 설정)
+# DB_POOL_SIZE=20
+# DB_MAX_OVERFLOW=60
+# DB_THREADPOOL_CAPACITY=100
+
 # pgAdmin 설정 (로컬 개발용 — docker-compose.dev.yml 에서만 사용)
 PGADMIN_DEFAULT_EMAIL=admin@example.com
 PGADMIN_DEFAULT_PASSWORD=admin123

--- a/database/api_server.py
+++ b/database/api_server.py
@@ -6,6 +6,9 @@ DB CRUD + Pipeline API (port 8020)
 import hmac
 import json
 import os
+from contextlib import asynccontextmanager
+
+import anyio
 from dotenv import load_dotenv
 from fastapi import FastAPI
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -14,6 +17,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 load_dotenv()
 
+from core.database import db_config
 from core.logging import configure_logging, RequestLoggingMiddleware
 
 configure_logging()
@@ -101,10 +105,20 @@ class InternalTokenMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # anyio 기본 스레드풀 capacity(40)는 동기 SQLAlchemy 세션 의존성(get_db)이 실행되는 곳.
+    # db_config.db_threadpool_capacity(DB_THREADPOOL_CAPACITY 환경변수, 기본 100)보다
+    # SQLAlchemy pool이 크면 풀보다 먼저 천장이 되므로, 풀 크기와 함께 db_config에서 관리한다.
+    anyio.to_thread.current_default_thread_limiter().total_tokens = db_config.db_threadpool_capacity
+    yield
+
+
 app = FastAPI(
     title="Database API",
     description="DB CRUD 및 Pipeline API",
     version="1.0.0",
+    lifespan=lifespan,
 )
 
 app.add_middleware(InternalTokenMiddleware)

--- a/database/core/database.py
+++ b/database/core/database.py
@@ -28,6 +28,13 @@ class DatabaseConfig:
         if password is None:
             raise ValueError("POSTGRES_PASSWORD 환경변수가 설정되지 않았습니다.")
         self.password = password
+        # Postgres max_connections(기본 100) 중 관리자/마이그레이션용으로 일부를 남기고
+        # 앱이 쓸 수 있는 실질 한도를 pool_size+max_overflow로 설정한다.
+        self.pool_size = int(os.getenv('DB_POOL_SIZE', 20))
+        self.max_overflow = int(os.getenv('DB_MAX_OVERFLOW', 60))
+        # 동기 DB 세션 의존성(get_db)이 실행되는 anyio 스레드풀 capacity.
+        # pool_size+max_overflow보다 작으면 풀 증설 효과가 무력화되므로 그 이상으로 맞춘다.
+        self.db_threadpool_capacity = int(os.getenv('DB_THREADPOOL_CAPACITY', 100))
 
     @property
     def database_url(self) -> str:
@@ -42,8 +49,8 @@ db_config = DatabaseConfig()
 engine = create_engine(
     db_config.database_url,
     echo=False,
-    pool_size=10,
-    max_overflow=20,
+    pool_size=db_config.pool_size,
+    max_overflow=db_config.max_overflow,
     pool_pre_ping=True,
     pool_recycle=3600,
 )


### PR DESCRIPTION
problem:
동시 100건 부하 테스트에서 성공률 70%(p99 31.7s), 동시 200건에서 39%(p99 62.5s)로 붕괴. 게이트웨이의 ~37s 타임아웃에 걸려 504로 응답.

as is:
- database/core/database.py: SQLAlchemy pool_size=10, max_overflow=20 (총 30)
- database/api_server.py: anyio 기본 스레드풀 capacity 40 (별도 설정 없음)
- Postgres 실제 max_connections=100 — 앱이 그중 30%만 사용, 70%는 미사용 여유였음

to be:
- SQLAlchemy pool_size=20, max_overflow=60 (총 80) — Postgres 100 중 20은 관리자/마이그레이션용으로 예약
- api_server.py lifespan에서 anyio 스레드풀 capacity를 100으로 상향 — 동기 DB 세션 의존성(get_db)이 이 스레드풀에서 실행되므로 풀(80)보다 작으면 풀 증설 효과가 무력화됨