### PR TITLE
fix: OpenSearch 동시 요청 폭발 — 세마포어 + 타임아웃 계층 수정

### DIFF
--- a/backend/app/agents/shared/product/product_client.py
+++ b/backend/app/agents/shared/product/product_client.py
@@ -8,6 +8,16 @@ import asyncio
 
 logger = get_logger("recommend_products")
 
+_opensearch_semaphore: asyncio.Semaphore | None = None
+
+
+def _get_opensearch_semaphore() -> asyncio.Semaphore:
+    global _opensearch_semaphore
+    if _opensearch_semaphore is None:
+        _opensearch_semaphore = asyncio.Semaphore(settings.opensearch_max_concurrent_searches)
+    return _opensearch_semaphore
+
+
 class ProductClient:
     def __init__(self):
         self.db_api_url = settings.database_api_url
@@ -20,7 +30,7 @@ class ProductClient:
         """httpx.AsyncClient lazy init (커넥션 풀 재사용)"""
         if self._http_client is None or self._http_client.is_closed:
             self._http_client = httpx.AsyncClient(
-                timeout=httpx.Timeout(settings.http_timeout_default),
+                timeout=httpx.Timeout(settings.http_timeout_long),
                 headers={"X-Internal-Token": settings.internal_token},
             )
         return self._http_client
@@ -254,27 +264,28 @@ class ProductClient:
         aggregation: str = "max",
     ) -> List[Dict[str, Any]]:
         """POST /api/search/multivector 호출 (내부용)"""
-        try:
-            response = await self.http_client.post(
-                f"{self.vector_db_api_url}/api/search/multivector",
-                json={
-                    "query": query,
-                    "index_name": index_name,
-                    "product_ids": product_ids,
-                    "top_k": top_k,
-                    "aggregation": aggregation,
-                },
-            )
-            response.raise_for_status()
-            return response.json().get("results", [])
-        except Exception as e:
-            logger.error(
-                "search_multivector.failed",
-                index_name=index_name,
-                error_type=type(e).__name__,
-                exc_info=True,
-            )
-            raise
+        async with _get_opensearch_semaphore():
+            try:
+                response = await self.http_client.post(
+                    f"{self.vector_db_api_url}/api/search/multivector",
+                    json={
+                        "query": query,
+                        "index_name": index_name,
+                        "product_ids": product_ids,
+                        "top_k": top_k,
+                        "aggregation": aggregation,
+                    },
+                )
+                response.raise_for_status()
+                return response.json().get("results", [])
+            except Exception as e:
+                logger.error(
+                    "search_multivector.failed",
+                    index_name=index_name,
+                    error_type=type(e).__name__,
+                    exc_info=True,
+                )
+                raise
 
     @traced(name="search_by_multivector_combined", run_type="retriever")
     async def search_by_multivector_combined(

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -230,7 +230,10 @@ class Settings(BaseSettings):
 
     # Database pool (psycopg async — LangGraph checkpointer)
     postgres_async_pool_min_size: int = 1
-    postgres_async_pool_max_size: int = 10
+    postgres_async_pool_max_size: int = 30
+
+    # OpenSearch 동시 검색 요청 상한 (세마포어)
+    opensearch_max_concurrent_searches: int = 20
 
     # Health check
     health_check_db_timeout: float = 2.0


### PR DESCRIPTION
problem:
동시 100명 CRM 채팅 요청 시 recommend_product_agent가 asyncio.gather()로 OpenSearch 쿼리를 무제한 병렬 호출 → 동시 470+ 쿼리가 단일 노드 OpenSearch에 집중 → ReadTimeout 전량 발생 → 파이프라인 완료율 0% (18차 부하 테스트 결과)

추가로 ProductClient httpx timeout(15s)이 OpenSearch 클라이언트 timeout(30s)보다 짧아 timeout 계층이 역전된 상태였음

as is:
- product_client.py: _search_multivector() 호출 시 Semaphore 없음 → 94 요청 × 5 OS 쿼리 = 동시 470+ 쿼리
- ProductClient httpx timeout: http_timeout_default = 15s (OpenSearch 클라이언트 30s보다 짧음)
- postgres_async_pool_max_size: 10 (100 동시 CRM 그래프 체크포인터 접속 시 부족)

to be:
- _search_multivector() 진입 시 asyncio.Semaphore(opensearch_max_concurrent_searches) 획득 → 동시 OS 쿼리 최대 20개로 제한, 나머지는 대기 후 순차 처리
- ProductClient httpx timeout: http_timeout_long = 30s (OS 클라이언트와 동일)
- opensearch_max_concurrent_searches: int = 20 Settings 항목 추가 (환경변수로 조정 가능)
- postgres_async_pool_max_size: 10 → 30