### PR TITLE
fix: A2A·그래프 타임아웃 계층 수정 — recommend 2배치·ALB 경쟁 조건 해소

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Windows crash dumps
+*.stackdump
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -135,7 +135,7 @@ class Settings(BaseSettings):
     recommend_agent_url: str = "http://localhost:8001"
     generate_message_agent_url: str = "http://localhost:8002"
     data_registration_agent_url: str = "http://localhost:8003"
-    a2a_timeout: float = 120.0
+    a2a_timeout: float = 280.0
     a2a_max_retries: int = Field(default=3, ge=1)
 
     # CRM Service (내부 전용)
@@ -170,7 +170,7 @@ class Settings(BaseSettings):
 
     # LangGraph
     langgraph_recursion_limit: int = 100
-    graph_execution_timeout: float = 300.0
+    graph_execution_timeout: float = 600.0
 
     # Product recommendation tuning
     rrf_k: int = 60


### PR DESCRIPTION
problem:
- A2A timeout(120s) < recommend 2번째 배치 처리 시간(~188s) → batch2 요청이 도중에 A2A timeout → CRM 재시도 → 부하 증가
- ALB idle timeout(300s) = graph_execution_timeout(300s) → 경쟁 조건으로 68건 HTTP 504 (20차 테스트 기준)

as is:
- a2a_timeout: 120s
- graph_execution_timeout: 300s

to be:
- a2a_timeout: 280s (batch2 완료 ~188s + 여유)
- graph_execution_timeout: 600s (ALB idle 660s 이내)

ALB idle timeout은 콘솔/CLI에서 별도 300s → 660s 변경 필요