### PR TITLE
fix: OpenSearch 동시성 보호를 프로세스 간 진짜 공유 지점으로 이전

### DIFF
--- a/backend/app/agents/generate_message_agent/services/quality_check.py
+++ b/backend/app/agents/generate_message_agent/services/quality_check.py
@@ -23,7 +23,7 @@ from ....core.data_loader import get_forbidden_keywords, get_brand_tone
 from ....core.llm_utils import ainvoke_with_timeout
 from ....config.settings import settings
 from ....core.http_client_registry import register
-from ...shared.product.product_client import ProductClient, _get_opensearch_semaphore
+from ...shared.product.product_client import ProductClient
 
 logger = get_logger("quality_check")
 
@@ -469,15 +469,14 @@ class QualityChecker:
         """
         for attempt in range(1, settings.quality_check_semantic_max_retries + 1):
             try:
-                async with _get_opensearch_semaphore():
-                    response = await client.post(
-                        endpoint,
-                        json={
-                            "index_name": settings.opensearch_forbidden_sentences_index,
-                            "query": sentence,
-                            "top_k": settings.quality_check_semantic_top_k,
-                        },
-                    )
+                response = await client.post(
+                    endpoint,
+                    json={
+                        "index_name": settings.opensearch_forbidden_sentences_index,
+                        "query": sentence,
+                        "top_k": settings.quality_check_semantic_top_k,
+                    },
+                )
                 response.raise_for_status()
                 data = response.json()
                 return [

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -235,9 +235,10 @@ class Settings(BaseSettings):
     # OpenSearch 동시 검색 요청 상한 (세마포어)
     opensearch_max_concurrent_searches: int = 20
 
-    # /chat/v2/stream 진입 동시성 게이팅 — OpenSearch 보호는 opensearch_max_concurrent_searches
-    # 세마포어(recommend_product_agent·quality_check 공유)가 전담하므로, 진입 단계는 동시
-    # 100명까지 허용. 그래프 실행(astream_events) 시작 전 세마포어 슬롯을 획득.
+    # /chat/v2/stream 진입 동시성 게이팅 — OpenSearch 보호는 opensearch_api.py(fastapi-search,
+    # recommend-agent·generate-agent가 공통으로 호출하는 단일 서버 프로세스)의 워커별 세마포어가
+    # 전담하므로, 진입 단계는 동시 100명까지 허용. 그래프 실행(astream_events) 시작 전 세마포어
+    # 슬롯을 획득.
     chat_stream_max_concurrent: int = 100
     chat_stream_admission_timeout: float = 300.0  # 슬롯 대기 최대 시간 (초) — 실제 처리시간(~150s) 대비 여유
 

--- a/opensearch/opensearch_api.py
+++ b/opensearch/opensearch_api.py
@@ -187,6 +187,12 @@ app.add_middleware(_BodySizeLimitMiddleware, max_body_bytes=_MAX_BODY_BYTES)
 # OpenSearch 클라이언트 (싱글톤)
 opensearch_client = None
 
+# OpenSearch 클러스터 동시 검색 요청 상한 — 이 서비스는 recommend-agent·generate-agent가
+# 공통으로 호출하는 단일 지점이라, 여기서 게이팅해야 두 호출자 간에 실제로 예산이 공유된다.
+# 프로덕션은 워커 4개로 떠서(uvicorn workers=4) 워커마다 별도 프로세스이므로, 워커별 예산을
+# 나눠서 총합이 전체 예산에 근접하도록 한다.
+_search_semaphore = asyncio.Semaphore(int(os.getenv("OPENSEARCH_MAX_CONCURRENT_SEARCHES_PER_WORKER", "5")))
+
 
 # 요청/응답 모델
 class ProductIDSearchRequest(BaseModel):
@@ -440,11 +446,12 @@ async def get_product_by_id(
         }
 
         # 검색 실행
-        response = await asyncio.to_thread(
-            client.client.search,
-            index=index_name,
-            body=query_body,
-        )
+        async with _search_semaphore:
+            response = await asyncio.to_thread(
+                client.client.search,
+                index=index_name,
+                body=query_body,
+            )
 
         hits = response.get("hits", {}).get("hits", [])
 
@@ -564,14 +571,15 @@ async def search_by_product_ids(request: ProductIDSearchRequest):
         }
 
         # 검색 실행
-        raw_results = await asyncio.to_thread(
-            client.search_with_pipeline,
-            query_text=request.query,
-            pipeline_id=request.pipeline_id,
-            index_name=request.index_name,
-            query_body=query_body,
-            top_k=request.top_k,
-        )
+        async with _search_semaphore:
+            raw_results = await asyncio.to_thread(
+                client.search_with_pipeline,
+                query_text=request.query,
+                pipeline_id=request.pipeline_id,
+                index_name=request.index_name,
+                query_body=query_body,
+                top_k=request.top_k,
+            )
 
         # 결과 포맷팅
         results = []
@@ -641,11 +649,12 @@ async def search_similar_sentences(request: SimilarSentenceRequest):
             }
         }
 
-        response = await asyncio.to_thread(
-            client.client.search,
-            index=request.index_name,
-            body=query_body,
-        )
+        async with _search_semaphore:
+            response = await asyncio.to_thread(
+                client.client.search,
+                index=request.index_name,
+                body=query_body,
+            )
 
         hits = response.get("hits", {}).get("hits", [])
 
@@ -707,16 +716,17 @@ async def search_by_combined_vector(request: ProductIDSearchRequest):
         pipeline_body = client._create_search_pipe_line_body()
         client.create_search_pipeline(pipeline_id=request.pipeline_id, pipeline_body=pipeline_body)
 
-        raw_results = await asyncio.to_thread(
-            client.search_combined,
-            query_text=request.query,
-            product_ids=request.product_ids,
-            top_k=request.top_k,
-            index_name=request.index_name,
-            pipeline_id=request.pipeline_id,
-            bm25_fields=request.bm25_fields,
-            vector_field=request.vector_field or "combined_vector",
-        )
+        async with _search_semaphore:
+            raw_results = await asyncio.to_thread(
+                client.search_combined,
+                query_text=request.query,
+                product_ids=request.product_ids,
+                top_k=request.top_k,
+                index_name=request.index_name,
+                pipeline_id=request.pipeline_id,
+                bm25_fields=request.bm25_fields,
+                vector_field=request.vector_field or "combined_vector",
+            )
 
         results = [
             CombinedSearchResult(
@@ -763,16 +773,17 @@ async def search_by_field(request: FieldSearchRequest):
         pipeline_body = client._create_search_pipe_line_body()
         client.create_search_pipeline(pipeline_id=request.pipeline_id, pipeline_body=pipeline_body)
 
-        raw_results = await asyncio.to_thread(
-            client.search_by_field,
-            query_text=request.query,
-            bm25_fields=request.bm25_fields,
-            vector_field=request.vector_field,
-            product_ids=request.product_ids,
-            top_k=request.top_k,
-            index_name=request.index_name,
-            pipeline_id=request.pipeline_id,
-        )
+        async with _search_semaphore:
+            raw_results = await asyncio.to_thread(
+                client.search_by_field,
+                query_text=request.query,
+                bm25_fields=request.bm25_fields,
+                vector_field=request.vector_field,
+                product_ids=request.product_ids,
+                top_k=request.top_k,
+                index_name=request.index_name,
+                pipeline_id=request.pipeline_id,
+            )
 
         results = [
             FieldSearchResult(
@@ -818,15 +829,16 @@ async def search_multivector(request: MultiVectorSearchRequest):
         pipeline_body = client._create_search_pipe_line_body()
         client.create_search_pipeline(pipeline_id=request.pipeline_id, pipeline_body=pipeline_body)
         
-        raw_results = await asyncio.to_thread(
-            client.search_multivector_field,
-            query_text=request.query,
-            index_name=request.index_name,
-            product_ids=request.product_ids,
-            top_k=request.top_k,
-            aggregation=request.aggregation,
-            pipeline_id=request.pipeline_id,
-        )
+        async with _search_semaphore:
+            raw_results = await asyncio.to_thread(
+                client.search_multivector_field,
+                query_text=request.query,
+                index_name=request.index_name,
+                product_ids=request.product_ids,
+                top_k=request.top_k,
+                aggregation=request.aggregation,
+                pipeline_id=request.pipeline_id,
+            )
 
         results = [
             FieldSearchResult(score=item["score"], product_id=item["product_id"])
@@ -890,7 +902,8 @@ async def index_multivector(request: IndexMultivectorRequest):
                     "embedding_model": _EMBEDDING_MODEL_VERSION,
                 })
 
-            response = await asyncio.to_thread(client.client.bulk, body=bulk_body, refresh=True)
+            async with _search_semaphore:
+                response = await asyncio.to_thread(client.client.bulk, body=bulk_body, refresh=True)
             failed_ids = {
                 item["index"]["_id"]
                 for item in response.get("items", [])


### PR DESCRIPTION
problem:
직전 수정에서 recommend-agent(8001)와 generate-agent(8002) 사이에 OpenSearch 세마포어를 "공유"시켜 동시 호출을 제한하려 했으나, 두 서비스는 서로 다른 ECS
서비스=서로 다른 프로세스라서 asyncio.Semaphore가 실제로 공유되지 않았다(같은 코드를 import해도 프로세스마다 독립된 세마포어 인스턴스가 생성됨). 그 결과
ECS 태스크 수에 따라 실제 동시 OpenSearch 호출이 (recommend 태스크수×20)+ (generate 태스크수×20)으로 배가될 수 있는 상태가 그대로 남아있었다 — 21차
문서가 이미 지적한 "recommend 3인스턴스×20=60" 구조적 한계와 동일.

as is:
- quality_check.py가 product_client.py의 _get_opensearch_semaphore를 import해 "공유"한다고 가정했으나 실제로는 프로세스 로컬 세마포어 두 개가 독립적으로 존재하는 상태
- settings.py 주석이 이 잘못된 가정("recommend_product_agent·quality_check 공유")을 명시하고 있었음

to be:
- quality_check.py의 해당 import/wrap을 원복 — 효과 없는 코드를 제거해 오해 소지를 없앰
- 진짜 공유 지점인 opensearch/opensearch_api.py(fastapi-search, 8010)에 세마포어 추가 — recommend-agent·generate-agent가 OpenSearch 클러스터에 접근하는 유일한 공통 경로이므로, 여기서 게이팅해야 호출자와 무관하게 같은 예산을 공유함. 프로덕션이 워커 4개(uvicorn workers=4)로 뜨는 점을 고려해 OPENSEARCH_MAX_CONCURRENT_SEARCHES_PER_WORKER(기본 5, 총 20)로 워커별 예산을 나눔. 실제 OpenSearch 클러스터 호출(client.client.search/bulk) 7곳을 세마포어로 감쌈(임베딩 모델 추론 호출 3곳은 별개 리소스라 제외)
- settings.py 주석을 실제 보호 지점(opensearch_api.py)으로 정정