### PR TITLE
fix: OpenSearch 세마포어 기본값을 실제 워커 수(1)에 맞게 정정

### DIFF
--- a/opensearch/opensearch_api.py
+++ b/opensearch/opensearch_api.py
@@ -189,9 +189,9 @@ opensearch_client = None
 
 # OpenSearch 클러스터 동시 검색 요청 상한 — 이 서비스는 recommend-agent·generate-agent가
 # 공통으로 호출하는 단일 지점이라, 여기서 게이팅해야 두 호출자 간에 실제로 예산이 공유된다.
-# 프로덕션은 워커 4개로 떠서(uvicorn workers=4) 워커마다 별도 프로세스이므로, 워커별 예산을
-# 나눠서 총합이 전체 예산에 근접하도록 한다.
-_search_semaphore = asyncio.Semaphore(int(os.getenv("OPENSEARCH_MAX_CONCURRENT_SEARCHES_PER_WORKER", "5")))
+# 프로덕션은 systemd가 단일 워커로 띄우므로(uvicorn --workers 1) 워커 분할 없이 전체
+# 예산을 그대로 사용한다.
+_search_semaphore = asyncio.Semaphore(int(os.getenv("OPENSEARCH_MAX_CONCURRENT_SEARCHES_PER_WORKER", "20")))
 
 
 # 요청/응답 모델


### PR DESCRIPTION
problem:
opensearch_api.py에 추가한 세마포어 기본값을 "워커 4개 × 5 = 총 20"으로 계산해서 5로 넣었으나, 실제 AWS 프로덕션은 systemd가 uvicorn을
--workers 1로(단일 워커) 띄운다(opensearch-api.service ExecStart 확인). 파일 안 __main__ 블록의 workers=4는 `python opensearch_api.py`로 직접 실행할 때만 적용되는 코드로, 실제 배포 경로(systemd)에서는 쓰이지 않는다. 그 결과
실제 동시 OpenSearch 호출 상한이 의도한 20이 아니라 5로 과도하게 낮게 걸려있었음.

as is:
_search_semaphore = asyncio.Semaphore(int(os.getenv("...", "5")))

to be:
_search_semaphore = asyncio.Semaphore(int(os.getenv("...", "20"))) — 워커가 1개뿐이므로 분할 없이 전체 예산(20)을 그대로 사용