### PR TITLE
fix: 품질검사 시맨틱 검색을 배치 인코딩으로 전환 — 임베딩 CPU 경합 해소

### DIFF
--- a/backend/app/agents/generate_message_agent/services/quality_check.py
+++ b/backend/app/agents/generate_message_agent/services/quality_check.py
@@ -389,7 +389,7 @@ class QualityChecker:
             - passed=True  → 금지 표현 없음
             - passed=False → 임계값 초과 결과 목록 또는 API 오류 마커 반환
         """
-        endpoint = f"{settings.opensearch_api_url}/api/search/similar-sentences"
+        endpoint = f"{settings.opensearch_api_url}/api/search/similar-sentences/batch"
 
         full_text = f"{title} {message}".strip()
 
@@ -403,21 +403,18 @@ class QualityChecker:
         if not sentences:
             return True, []
 
-        all_results: List[Dict[str, Any]] = []
-
-        search_tasks = [self._search_sentence(self.http_client, s, endpoint) for s in sentences]
-        results_per_sentence = await asyncio.gather(*search_tasks)
+        results_per_sentence = await self._search_sentences_batch(self.http_client, sentences, endpoint)
 
         # API 오류 시 검사 불가 → 실패 처리 (컴플라이언스 의무)
-        api_errors = [s for s, r in zip(sentences, results_per_sentence) if r is None]
-        if api_errors:
+        if results_per_sentence is None:
             logger.warning(
                 "semantic_check_api_failed",
-                failed_count=len(api_errors),
+                failed_count=len(sentences),
                 total=len(sentences),
             )
             return False, [{"error": "api_unavailable"}]
 
+        all_results: List[Dict[str, Any]] = []
         for results in results_per_sentence:
             all_results.extend(results)
 
@@ -449,23 +446,27 @@ class QualityChecker:
 
         return True, []
 
-    async def _search_sentence(
+    async def _search_sentences_batch(
         self,
         client: httpx.AsyncClient,
-        sentence: str,
+        sentences: List[str],
         endpoint: str,
-    ) -> Optional[List[Dict[str, Any]]]:
+    ) -> Optional[List[List[Dict[str, Any]]]]:
         """
-        단일 문장의 유사도 검색 요청을 보냅니다 (최대 ``quality_check_semantic_max_retries``회 재시도).
+        문장 리스트 전체를 한 번에 유사도 검색 요청으로 보냅니다(최대
+        ``quality_check_semantic_max_retries``회 배치 단위 재시도). 문장마다 인코딩을
+        따로 호출하지 않고 한 번에 묶어 OpenSearch 노드와 같은 인스턴스에서 도는
+        임베딩 모델의 CPU 경합을 줄입니다.
 
         Args:
-            client:   재사용할 httpx 비동기 클라이언트.
-            sentence: 유사도를 검색할 단일 문장.
-            endpoint: ``/api/search/similar-sentences`` 엔드포인트 URL.
+            client:    재사용할 httpx 비동기 클라이언트.
+            sentences: 유사도를 검색할 문장 리스트.
+            endpoint:  ``/api/search/similar-sentences/batch`` 엔드포인트 URL.
 
         Returns:
-            검색 결과 리스트 (각 항목은 ``query_sentence``, ``matched_sentence``,
-            ``score``, ``source`` 키를 포함). 모든 재시도 실패 시 ``None``.
+            문장별 검색 결과 리스트(입력 순서와 동일, 각 항목은 ``query_sentence``,
+            ``matched_sentence``, ``score``, ``source`` 키를 포함). 모든 재시도
+            실패 시 ``None``.
         """
         for attempt in range(1, settings.quality_check_semantic_max_retries + 1):
             try:
@@ -473,25 +474,28 @@ class QualityChecker:
                     endpoint,
                     json={
                         "index_name": settings.opensearch_forbidden_sentences_index,
-                        "query": sentence,
+                        "queries": sentences,
                         "top_k": settings.quality_check_semantic_top_k,
                     },
                 )
                 response.raise_for_status()
                 data = response.json()
                 return [
-                    {
-                        "query_sentence": sentence,
-                        "matched_sentence": r.get("sentence"),
-                        "score": r.get("score", 0.0),
-                        "source": r.get("source", {}),
-                    }
-                    for r in data.get("results", [])
+                    [
+                        {
+                            "query_sentence": item["query"],
+                            "matched_sentence": r.get("sentence"),
+                            "score": r.get("score", 0.0),
+                            "source": r.get("source", {}),
+                        }
+                        for r in item.get("results", [])
+                    ]
+                    for item in data.get("results", [])
                 ]
             except Exception as e:
                 logger.warning(
-                    "semantic_search_request_failed",
-                    sentence=sentence,
+                    "semantic_search_batch_request_failed",
+                    sentence_count=len(sentences),
                     attempt=attempt,
                     max_retries=settings.quality_check_semantic_max_retries,
                     error_type=type(e).__name__,

--- a/loadtest/_build_parse.py
+++ b/loadtest/_build_parse.py
@@ -1,0 +1,9 @@
+import json
+
+commands = [
+    "cd /home/ubuntu/loadtest && python3 parse_results.py results/20260618T171826Z 2>&1 | tail -60",
+]
+
+with open(r"C:\Users\user\AppData\Local\Temp\parse_params.json", "w") as f:
+    json.dump({"commands": commands}, f)
+print("ok")

--- a/opensearch/opensearch_api.py
+++ b/opensearch/opensearch_api.py
@@ -253,6 +253,23 @@ class SimilarSentenceResponse(BaseModel):
     results: List[SimilarSentenceResult]
 
 
+class SimilarSentenceBatchRequest(BaseModel):
+    index_name: ValidatedIndexName = Field(..., description="검색할 인덱스 이름 (예: forbidden_sentences)")
+    queries: List[str] = Field(..., description="유사 문장을 찾을 검색 쿼리 텍스트 리스트", min_length=1, max_length=200)
+    top_k: int = Field(default=3, ge=1, le=100, description="쿼리당 반환할 유사 문장 개수 (기본값: 3)")
+
+
+class SimilarSentenceBatchResult(BaseModel):
+    query: str
+    results: List[SimilarSentenceResult]
+
+
+class SimilarSentenceBatchResponse(BaseModel):
+    success: bool
+    index_name: str
+    results: List[SimilarSentenceBatchResult]
+
+
 class ProductResult(BaseModel):
     score: float
     product_id: Optional[str] = None
@@ -701,6 +718,97 @@ async def search_similar_sentences(request: SimilarSentenceRequest):
             status_code=500,
             detail="검색 중 오류가 발생했습니다."
         )
+
+
+@app.post("/api/search/similar-sentences/batch", response_model=SimilarSentenceBatchResponse)
+async def search_similar_sentences_batch(request: SimilarSentenceBatchRequest):
+    """
+    여러 쿼리 문장을 한 번에 인코딩 후 각각 KNN 검색 — 품질검사처럼 메시지를 문장
+    단위로 쪼개 검사할 때, 문장마다 인코딩을 따로 호출하는 대신 한 번에 묶어서
+    처리해 임베딩 모델의 CPU 사용을 줄인다(OpenSearch 노드와 같은 인스턴스에서
+    돌기 때문에 인코딩 호출 수 자체가 OpenSearch 검색 성능에 영향을 준다).
+
+    - **index_name**: 검색할 인덱스 이름 (예: forbidden_sentences)
+    - **queries**: 유사 문장을 찾을 검색 쿼리 텍스트 리스트 (필수)
+    - **top_k**: 쿼리당 반환할 결과 개수 (기본값: 3)
+    """
+    try:
+        logger.info(
+            "search_similar_batch_requested",
+            index_name=request.index_name,
+            query_count=len(request.queries),
+        )
+
+        client = get_opensearch_client()
+
+        async with _search_semaphore:
+            # 쿼리 벡터 일괄 생성 — 문장 수만큼 encode를 반복하지 않고 한 번만 호출
+            query_vectors = await asyncio.to_thread(client.model.encode, request.queries)
+
+            batch_results: List[SimilarSentenceBatchResult] = []
+            for query, vector in zip(request.queries, query_vectors):
+                query_body = {
+                    "size": request.top_k,
+                    "query": {
+                        "knn": {
+                            "sentence_vector": {
+                                "vector": vector.tolist(),
+                                "k": request.top_k
+                            }
+                        }
+                    },
+                    "_source": {
+                        "excludes": ["sentence_vector"]
+                    }
+                }
+                response = await asyncio.to_thread(
+                    client.client.search,
+                    index=request.index_name,
+                    body=query_body,
+                )
+                hits = response.get("hits", {}).get("hits", [])
+                results = [
+                    SimilarSentenceResult(
+                        score=hit.get("_score", 0.0),
+                        sentence=(hit.get("_source", {}).get("sentence")
+                                  or hit.get("_source", {}).get("문장")
+                                  or hit.get("_source", {}).get("text")),
+                        source=hit.get("_source", {})
+                    )
+                    for hit in hits
+                ]
+                batch_results.append(SimilarSentenceBatchResult(query=query, results=results))
+
+        logger.info("search_similar_batch_completed", query_count=len(request.queries))
+
+        return SimilarSentenceBatchResponse(
+            success=True,
+            index_name=request.index_name,
+            results=batch_results,
+        )
+
+    except Exception as e:
+        # 인덱스가 존재하지 않는 경우 빈 결과 반환 (Stage 2 통과 처리) — 단건 엔드포인트와 동일 정책
+        error_info = getattr(e, "info", {}) or {}
+        if (
+            getattr(e, "status_code", None) == 404
+            or error_info.get("error", {}).get("type") == "index_not_found_exception"
+        ):
+            logger.warning(
+                "search_similar_batch_index_not_found",
+                index_name=request.index_name,
+            )
+            return SimilarSentenceBatchResponse(
+                success=True,
+                index_name=request.index_name,
+                results=[SimilarSentenceBatchResult(query=q, results=[]) for q in request.queries],
+            )
+        logger.error("search_similar_sentences_batch_failed", exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail="검색 중 오류가 발생했습니다."
+        )
+
 
 @app.post("/api/search/combined", response_model=CombinedSearchResponse)
 async def search_by_combined_vector(request: ProductIDSearchRequest):


### PR DESCRIPTION
fix: 품질검사 시맨틱 검색을 배치 인코딩으로 전환 — 임베딩 CPU 경합 해소

problem:
23차 부하테스트(동시 100명)에서 HTTP 200은 100/100이었지만 파이프라인 완료는 여전히 0/100, OpenSearch EC2 CPU는 99.8~99.9%로 계속 스파이크했다. 직전에 opensearch_api.py에 추가한 세마포어는 client.client.search/bulk 호출만 감쌌고 임베딩 인코딩(client.model.encode)은 제외했는데, opensearch_api.py (fastapi-search)가 OpenSearch 노드와 같은 EC2 인스턴스에서 systemd로 직접 실행되는(workers=1) 구조라 인코딩과 OpenSearch 검색 스레드가 같은 CPU를 공유한다. 품질검사가 메시지를 문장 단위로 쪼개 문장마다(요청당 ~24회) 인코딩을
따로 호출하다 보니, 100명이 몰리면 인코딩만으로 CPU를 다 써서 검색 스레드가
굶었다(품질검사 실패 1,476건 중 918건이 ReadTimeout, quality_check_started는 31/100건뿐).

as is:
- opensearch_api.py: /api/search/similar-sentences가 문장 1개씩만 받아 매번 client.model.encode(단일 문장)를 호출
- quality_check.py: _search_sentence()가 문장마다 따로 HTTP 호출, asyncio.gather로 문장 수만큼 동시 발사

to be:
- opensearch_api.py: /api/search/similar-sentences/batch 신규 추가 — queries: list[str]를 받아 client.model.encode(queries) 1회로 일괄 인코딩 후 문장별 KNN 검색(전체를 _search_semaphore로 보호). 기존 단건 엔드포인트는 다른 호출자를 위해 그대로 유지
- quality_check.py: _search_sentence → _search_sentences_batch로 교체, 메시지의 문장 리스트 전체를 배치 엔드포인트로 한 번에 전송. 재시도도 배치 단위로 수행
- 요청당 인코딩 호출 수를 ~24회 → ~1회로 줄여 CPU 경합 자체를 줄임(세마포어로 줄세우기만 하는 게 아니라 일의 양을 줄이는 방향)