### PR TITLE
fix: 임베딩 추론을 OpenSearch 노드와 분리 — 전용 EC2로 이전

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,6 +104,15 @@ jobs:
             "s3://${PROJECT_NAME}-deploy/opensearch_setup.${HASH}.sh" \
             || echo "bucket not ready (first deploy) — package job will upload"
 
+      - name: Upload versioned opensearch_api_setup.sh to S3
+        id: setup-hash-api
+        run: |
+          HASH=$(sha256sum infra/ec2/user_data/opensearch_api_setup.sh | cut -c1-16)
+          echo "hash=$HASH" >> $GITHUB_OUTPUT
+          aws s3 cp infra/ec2/user_data/opensearch_api_setup.sh \
+            "s3://${PROJECT_NAME}-deploy/opensearch_api_setup.${HASH}.sh" \
+            || echo "bucket not ready (first deploy) — package job will upload"
+
       - name: Terraform Apply
         working-directory: infra/ec2
         run: terraform apply -auto-approve
@@ -113,7 +122,8 @@ jobs:
           TF_VAR_environment:   production
           TF_VAR_ecr_registry:  "${{ steps.account.outputs.id }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com"
           TF_VAR_ecr_image_tag: ${{ github.sha }}
-          TF_VAR_opensearch_setup_hash: ${{ steps.setup-hash.outputs.hash }}
+          TF_VAR_opensearch_setup_hash:     ${{ steps.setup-hash.outputs.hash }}
+          TF_VAR_opensearch_api_setup_hash: ${{ steps.setup-hash-api.outputs.hash }}
 
           # ── 시크릿 (GitHub Secrets에서 주입) ──
           TF_VAR_opensearch_admin_password: ${{ secrets.OPENSEARCH_ADMIN_PASSWORD }}
@@ -136,14 +146,16 @@ jobs:
         run: |
           echo "db_instance_id=$(terraform output -raw db_ec2_instance_id)" >> $GITHUB_OUTPUT
           echo "opensearch_instance_id=$(terraform output -raw opensearch_ec2_instance_id)" >> $GITHUB_OUTPUT
+          echo "opensearch_api_instance_id=$(terraform output -raw opensearch_api_ec2_instance_id)" >> $GITHUB_OUTPUT
           echo "cloudfront_dist_id=$(terraform output -raw cloudfront_distribution_id)" >> $GITHUB_OUTPUT
           echo "frontend_bucket=$(terraform output -raw frontend_s3_bucket)" >> $GITHUB_OUTPUT
 
     outputs:
-      db_instance_id:         ${{ steps.tf-outputs.outputs.db_instance_id }}
-      opensearch_instance_id: ${{ steps.tf-outputs.outputs.opensearch_instance_id }}
-      cloudfront_dist_id:     ${{ steps.tf-outputs.outputs.cloudfront_dist_id }}
-      frontend_bucket:        ${{ steps.tf-outputs.outputs.frontend_bucket }}
+      db_instance_id:             ${{ steps.tf-outputs.outputs.db_instance_id }}
+      opensearch_instance_id:     ${{ steps.tf-outputs.outputs.opensearch_instance_id }}
+      opensearch_api_instance_id: ${{ steps.tf-outputs.outputs.opensearch_api_instance_id }}
+      cloudfront_dist_id:         ${{ steps.tf-outputs.outputs.cloudfront_dist_id }}
+      frontend_bucket:            ${{ steps.tf-outputs.outputs.frontend_bucket }}
 
   # ────────────────────────────────────────────
   # Job 3: 데이터 서비스 코드 패키징 → S3 업로드
@@ -169,6 +181,12 @@ jobs:
           HASH=$(sha256sum infra/ec2/user_data/opensearch_setup.sh | cut -c1-16)
           aws s3 cp infra/ec2/user_data/opensearch_setup.sh \
             "s3://${{ env.PROJECT_NAME }}-deploy/opensearch_setup.${HASH}.sh"
+
+      - name: Upload versioned opensearch_api_setup.sh to S3 (first-deploy safety net)
+        run: |
+          HASH=$(sha256sum infra/ec2/user_data/opensearch_api_setup.sh | cut -c1-16)
+          aws s3 cp infra/ec2/user_data/opensearch_api_setup.sh \
+            "s3://${{ env.PROJECT_NAME }}-deploy/opensearch_api_setup.${HASH}.sh"
 
       - name: Cache OpenSearch tarball in S3 (skip if already uploaded)
         run: |
@@ -311,19 +329,12 @@ jobs:
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids "${{ needs.terraform.outputs.opensearch_instance_id }}" \
             --document-name "AWS-RunShellScript" \
-            --timeout-seconds 1800 \
+            --timeout-seconds 600 \
             --parameters '{"commands":[
               "/usr/local/bin/aws s3 cp s3://${{ env.PROJECT_NAME }}-deploy/opensearch.tar.gz /tmp/opensearch.tar.gz",
-              "tar -xzf /tmp/opensearch.tar.gz -C /opt/opensearch-api",
-              "/usr/local/bin/aws s3 cp s3://${{ env.PROJECT_NAME }}-deploy/data.tar.gz /tmp/data.tar.gz",
-              "mkdir -p /opt/data && tar -xzf /tmp/data.tar.gz -C /opt/",
-              "chmod +x /opt/opensearch-api/restore_or_skip.sh /opt/opensearch-api/create_snapshot.sh /opt/opensearch-api/index_forbidden.sh",
-              "for i in $(seq 1 60); do [ -f /var/log/venv-ready ] && break; echo \"Waiting for venv ($i/60)...\"; sleep 30; done; [ -f /var/log/venv-ready ] || { echo ERROR: venv not ready; exit 1; }",
-              "/data/opensearch-api-venv/bin/pip install -q -r /opt/opensearch-api/requirements.txt",
-              "chown -R ubuntu:ubuntu /opt/opensearch-api",
-              "systemctl stop opensearch-api 2>/dev/null || true",
-              "/opt/opensearch-api/index_forbidden.sh",
-              "systemctl restart opensearch-api"
+              "mkdir -p /opt/opensearch-api && tar -xzf /tmp/opensearch.tar.gz -C /opt/opensearch-api",
+              "chmod +x /opt/opensearch-api/restore_or_skip.sh /opt/opensearch-api/create_snapshot.sh",
+              "chown -R ubuntu:ubuntu /opt/opensearch-api"
             ]}' \
             --output text --query "Command.CommandId")
           echo "SSM Command ID (opensearch): $COMMAND_ID"
@@ -344,6 +355,74 @@ jobs:
             fi
             if [ "$i" = "120" ]; then
               echo "ERROR: OpenSearch deploy did not complete within 30 minutes."
+              exit 1
+            fi
+          done
+
+      - name: Wait for OpenSearch API EC2 user_data to complete
+        run: |
+          echo "Waiting for OpenSearch API EC2 user_data to complete..."
+          for i in $(seq 1 80); do
+            RESULT=$(aws ssm send-command \
+              --instance-ids "${{ needs.terraform.outputs.opensearch_api_instance_id }}" \
+              --document-name "AWS-RunShellScript" \
+              --parameters '{"commands":["test -f /var/log/user-data-complete && echo OK || echo WAIT"]}' \
+              --output text --query "Command.CommandId")
+            sleep 5
+            STATUS=$(aws ssm get-command-invocation \
+              --command-id "$RESULT" \
+              --instance-id "${{ needs.terraform.outputs.opensearch_api_instance_id }}" \
+              --query "StandardOutputContent" --output text 2>/dev/null || echo "WAIT")
+            echo "Attempt $i: $STATUS"
+            if echo "$STATUS" | grep -q "OK"; then
+              echo "OpenSearch API EC2 user_data complete."
+              break
+            fi
+            if [ "$i" = "80" ]; then
+              echo "ERROR: OpenSearch API EC2 user_data did not complete within 40 minutes."
+              exit 1
+            fi
+            sleep 25
+          done
+
+      - name: Deploy to OpenSearch API EC2 via SSM
+        run: |
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-ids "${{ needs.terraform.outputs.opensearch_api_instance_id }}" \
+            --document-name "AWS-RunShellScript" \
+            --timeout-seconds 1800 \
+            --parameters '{"commands":[
+              "/usr/local/bin/aws s3 cp s3://${{ env.PROJECT_NAME }}-deploy/opensearch.tar.gz /tmp/opensearch.tar.gz",
+              "mkdir -p /opt/opensearch-api && tar -xzf /tmp/opensearch.tar.gz -C /opt/opensearch-api",
+              "/usr/local/bin/aws s3 cp s3://${{ env.PROJECT_NAME }}-deploy/data.tar.gz /tmp/data.tar.gz",
+              "mkdir -p /opt/data && tar -xzf /tmp/data.tar.gz -C /opt/",
+              "chmod +x /opt/opensearch-api/index_forbidden.sh",
+              "for i in $(seq 1 60); do [ -f /var/log/venv-ready ] && break; echo \"Waiting for venv ($i/60)...\"; sleep 30; done; [ -f /var/log/venv-ready ] || { echo ERROR: venv not ready; exit 1; }",
+              "/data/opensearch-api-venv/bin/pip install -q -r /opt/opensearch-api/requirements.txt",
+              "chown -R ubuntu:ubuntu /opt/opensearch-api",
+              "systemctl stop opensearch-api 2>/dev/null || true",
+              "/opt/opensearch-api/index_forbidden.sh",
+              "systemctl restart opensearch-api"
+            ]}' \
+            --output text --query "Command.CommandId")
+          echo "SSM Command ID (opensearch-api): $COMMAND_ID"
+          for i in $(seq 1 120); do
+            sleep 15
+            STATUS=$(aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" \
+              --instance-id "${{ needs.terraform.outputs.opensearch_api_instance_id }}" \
+              --query "Status" --output text 2>/dev/null || echo "Pending")
+            echo "Attempt $i: $STATUS"
+            if [ "$STATUS" = "Success" ]; then echo "OpenSearch API deploy success."; break; fi
+            if [ "$STATUS" = "Failed" ] || [ "$STATUS" = "Cancelled" ]; then
+              aws ssm get-command-invocation \
+                --command-id "$COMMAND_ID" \
+                --instance-id "${{ needs.terraform.outputs.opensearch_api_instance_id }}" \
+                --query "StandardErrorContent" --output text
+              exit 1
+            fi
+            if [ "$i" = "120" ]; then
+              echo "ERROR: OpenSearch API deploy did not complete within 30 minutes."
               exit 1
             fi
           done

--- a/infra/ec2/ec2.tf
+++ b/infra/ec2/ec2.tf
@@ -174,6 +174,60 @@ resource "aws_volume_attachment" "opensearch_data" {
   force_detach = true
 }
 
+# ---- OpenSearch API EC2 — 임베딩 추론(SentenceTransformer) 전용, OpenSearch 노드와 분리 ----
+# CPU 경합 해소 목적(부하테스트 23~24차에서 OpenSearch 노드와 같은 인스턴스에서 돌던
+# opensearch-api의 인코딩이 OpenSearch JVM 검색 스레드의 CPU를 빼앗는 현상을 확인).
+
+resource "aws_instance" "opensearch_api" {
+  ami                         = var.ec2_ami
+  instance_type               = var.opensearch_api_instance_type
+  subnet_id                   = aws_subnet.private[0].id
+  vpc_security_group_ids      = [aws_security_group.opensearch_api_ec2.id]
+  iam_instance_profile        = aws_iam_instance_profile.ec2.name
+  key_name                    = var.ec2_key_name != "" ? var.ec2_key_name : null
+  user_data_replace_on_change = true
+
+  user_data = base64encode(templatefile("${path.module}/user_data/opensearch_api_server.sh", {
+    project_name              = var.project_name
+    internal_token            = var.internal_token
+    opensearch_admin_password = var.opensearch_admin_password
+    opensearch_host           = aws_instance.opensearch.private_ip
+    setup_hash                = var.opensearch_api_setup_hash
+  }))
+
+  root_block_device {
+    volume_size           = 20
+    volume_type           = "gp3"
+    delete_on_termination = true
+  }
+
+  tags = { Name = "${var.project_name}-ec2-opensearch-api" }
+}
+
+# OpenSearch API venv 보존 볼륨 (torch/transformers — EC2 교체 시에도 재설치 스킵)
+resource "aws_ebs_volume" "opensearch_api_data" {
+  availability_zone = var.opensearch_api_az
+  size              = var.opensearch_api_ebs_volume_size_gb
+  type              = "gp3"
+  encrypted         = true
+
+  tags = {
+    Name   = "${var.project_name}-ebs-opensearch-api-data"
+    Backup = "true"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_volume_attachment" "opensearch_api_data" {
+  device_name  = "/dev/xvdf"
+  volume_id    = aws_ebs_volume.opensearch_api_data.id
+  instance_id  = aws_instance.opensearch_api.id
+  force_detach = true
+}
+
 # ---- S3 Deploy 버킷 (앱 코드 아카이브 저장) ----
 
 resource "aws_s3_bucket" "deploy" {

--- a/infra/ec2/ecs.tf
+++ b/infra/ec2/ecs.tf
@@ -18,7 +18,7 @@
 locals {
   # EC2 프라이빗 IP 기반 URL — ECS 태스크 환경변수에 주입
   db_api_url         = "http://${aws_instance.db.private_ip}:8020"
-  opensearch_api_url = "http://${aws_instance.opensearch.private_ip}:8010"
+  opensearch_api_url = "http://${aws_instance.opensearch_api.private_ip}:8010"
   postgres_url       = "postgresql://${var.postgres_user}:${var.postgres_password}@${aws_instance.db.private_ip}:5432/ai_innovation_db"
 }
 

--- a/infra/ec2/outputs.tf
+++ b/infra/ec2/outputs.tf
@@ -13,6 +13,11 @@ output "opensearch_ec2_private_ip" {
   value       = aws_instance.opensearch.private_ip
 }
 
+output "opensearch_api_ec2_private_ip" {
+  description = "OpenSearch API EC2 프라이빗 IP (임베딩 추론, OpenSearch 노드와 분리)"
+  value       = aws_instance.opensearch_api.private_ip
+}
+
 output "ecs_cluster_name" {
   description = "ECS 클러스터 이름"
   value       = aws_ecs_cluster.main.name
@@ -41,6 +46,11 @@ output "db_ec2_instance_id" {
 output "opensearch_ec2_instance_id" {
   description = "OpenSearch EC2 인스턴스 ID (SSM Run Command 타겟)"
   value       = aws_instance.opensearch.id
+}
+
+output "opensearch_api_ec2_instance_id" {
+  description = "OpenSearch API EC2 인스턴스 ID (SSM Run Command 타겟)"
+  value       = aws_instance.opensearch_api.id
 }
 
 output "deploy_s3_bucket" {

--- a/infra/ec2/security_groups.tf
+++ b/infra/ec2/security_groups.tf
@@ -4,7 +4,8 @@
 # 트래픽 흐름:
 #   인터넷 → ALB(sg_alb) → ECS tasks(sg_ecs_tasks)
 #   ECS tasks → DB EC2(sg_db_ec2)         [포트 5432, 8020]
-#   ECS tasks → OpenSearch EC2(sg_opensearch_ec2) [포트 8010]  ← 9200 직접 접근 차단
+#   ECS tasks → OpenSearch API EC2(sg_opensearch_api_ec2) [포트 8010]
+#   OpenSearch API EC2 → OpenSearch EC2(sg_opensearch_ec2) [포트 9200]  ← ECS는 직접 접근 차단
 #   ECS/EC2  → VPC Endpoints(sg_vpc_endpoints)   [포트 443]
 # -----------------------------------------------------------------------
 
@@ -125,7 +126,7 @@ resource "aws_security_group_rule" "ecs_to_db_api" {
 
 resource "aws_security_group" "opensearch_ec2" {
   name        = "${var.project_name}-sg-opensearch-ec2"
-  description = "OpenSearch EC2: OpenSearch API and native from ECS tasks only"
+  description = "OpenSearch EC2: native (9200) from opensearch-api EC2 only"
   vpc_id      = aws_vpc.main.id
 
   egress {
@@ -138,7 +139,36 @@ resource "aws_security_group" "opensearch_ec2" {
   tags = { Name = "${var.project_name}-sg-opensearch-ec2" }
 }
 
-# OpenSearch API(8010) — ECS tasks에서 HTTP 호출 (9200 직접 접근은 차단 — 인증 없는 경로 제거)
+# OpenSearch 네이티브(9200) — opensearch-api EC2(임베딩 추론, 검색 호출)에서만 접근
+# (ECS는 여전히 9200 직접 접근 불가 — 인증 없는 경로 차단 유지)
+resource "aws_security_group_rule" "opensearch_api_to_opensearch_native" {
+  type                     = "ingress"
+  description              = "OpenSearch native client - opensearch-api EC2 to OpenSearch"
+  from_port                = 9200
+  to_port                  = 9200
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.opensearch_api_ec2.id
+  security_group_id        = aws_security_group.opensearch_ec2.id
+}
+
+# ---- OpenSearch API EC2 (임베딩 추론, 별도 분리) ----
+
+resource "aws_security_group" "opensearch_api_ec2" {
+  name        = "${var.project_name}-sg-opensearch-api-ec2"
+  description = "OpenSearch API EC2: OpenSearch API(8010) from ECS tasks only"
+  vpc_id      = aws_vpc.main.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "${var.project_name}-sg-opensearch-api-ec2" }
+}
+
+# OpenSearch API(8010) — ECS tasks에서 HTTP 호출
 resource "aws_security_group_rule" "ecs_to_opensearch_api" {
   type                     = "ingress"
   description              = "OpenSearch API server - ECS to OpenSearch API"
@@ -146,7 +176,7 @@ resource "aws_security_group_rule" "ecs_to_opensearch_api" {
   to_port                  = 8010
   protocol                 = "tcp"
   source_security_group_id = aws_security_group.ecs_tasks.id
-  security_group_id        = aws_security_group.opensearch_ec2.id
+  security_group_id        = aws_security_group.opensearch_api_ec2.id
 }
 
 

--- a/infra/ec2/user_data/opensearch_api_server.sh
+++ b/infra/ec2/user_data/opensearch_api_server.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Bootstrap: AWS CLI 설치 후 S3에서 실제 설치 스크립트를 내려받아 실행한다.
+# 크기 제한: EC2 user_data는 base64 인코딩 후 16KB 이하 — 이 파일은 부트스트랩만 담는다.
+# 실제 설치 로직: infra/ec2/user_data/opensearch_api_setup.sh (S3 경유 배포)
+#
+# setup.sh는 내용 해시로 버전 키화된다: s3://.../opensearch_api_setup.<setup_hash>.sh
+#   - CI가 sha256으로 해시를 계산해 S3 업로드 + Terraform var로 주입
+#   - 이 부트스트랩이 해시 키만 받으므로 이전 배포의 낡은 setup.sh를 받는 race가 없다
+#   - setup.sh가 바뀌면 해시→user_data 변경→EC2 자동 교체 (수동 리비전 관리 불필요)
+SETUP_HASH="${setup_hash}"
+set -euo pipefail
+
+# Terraform templatefile 변수 → 쉘 환경변수로 export (setup.sh에서 사용)
+export PROJECT_NAME="${project_name}"
+export INTERNAL_TOKEN="${internal_token}"
+export OPENSEARCH_ADMIN_PASSWORD="${opensearch_admin_password}"
+export OPENSEARCH_HOST="${opensearch_host}"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a /var/log/user-data.log; }
+
+log "Bootstrap: installing curl + unzip + AWS CLI..."
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y -qq curl unzip
+
+curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+unzip -q /tmp/awscliv2.zip -d /tmp
+/tmp/aws/install
+rm -rf /tmp/awscliv2.zip /tmp/aws
+log "Bootstrap: AWS CLI installed."
+
+# 해시 키 setup.sh를 S3에서 대기 (terraform apply 전 CI가 업로드, 최대 20분)
+SETUP_KEY="opensearch_api_setup.$SETUP_HASH.sh"
+log "Bootstrap: waiting for $SETUP_KEY in S3..."
+SETUP_READY=false
+for i in $(seq 1 20); do
+  if /usr/local/bin/aws s3 cp \
+      "s3://$PROJECT_NAME-deploy/$SETUP_KEY" \
+      /tmp/opensearch_api_setup.sh 2>/dev/null; then
+    log "Bootstrap: setup script downloaded (attempt $i)."
+    SETUP_READY=true
+    break
+  fi
+  log "Bootstrap: not ready yet ($i/20), waiting 60s..."
+  sleep 60
+done
+
+if [ "$SETUP_READY" = "false" ]; then
+  log "ERROR: $SETUP_KEY not found in S3 after 20 minutes."
+  exit 1
+fi
+
+chmod +x /tmp/opensearch_api_setup.sh
+log "Bootstrap: executing opensearch_api_setup.sh..."
+exec bash /tmp/opensearch_api_setup.sh

--- a/infra/ec2/user_data/opensearch_api_setup.sh
+++ b/infra/ec2/user_data/opensearch_api_setup.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# OpenSearch API EC2 설치 스크립트 (임베딩 추론 전용 — opensearch_setup.sh와 분리)
+# opensearch_api_server.sh (user_data 부트스트랩)이 S3에서 내려받아 실행한다.
+# 환경변수는 부트스트랩에서 export된 값을 사용한다:
+#   PROJECT_NAME, INTERNAL_TOKEN, OPENSEARCH_ADMIN_PASSWORD, OPENSEARCH_HOST
+#
+# OpenSearch 노드와 같은 인스턴스에 있던 opensearch-api(SentenceTransformer 추론,
+# CPU-bound)를 별도 EC2로 분리한다 — 같은 CPU를 OpenSearch JVM 검색 스레드와
+# 나눠 쓰던 경합을 없애는 목적(부하테스트 23~24차에서 확인된 CPU 포화 원인).
+set -euo pipefail
+
+OPENSEARCH_API_DIR="/opt/opensearch-api"
+DATA_MOUNT="/data"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a /var/log/user-data.log; }
+trap 'log "FAILED at line $LINENO (exit $?)"' ERR
+
+# ---- 1. 시스템 업데이트 ----
+log "Waiting for apt lock..."
+systemctl stop unattended-upgrades apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
+systemctl kill --kill-who=all apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
+sleep 5
+for i in $(seq 1 30); do
+  if ! lsof /var/lib/dpkg/lock-frontend 2>/dev/null | grep -q dpkg; then break; fi
+  log "apt lock held, waiting... ($i/30)"
+  sleep 10
+done
+
+log "Updating system packages..."
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y -qq python3.11 python3.11-venv python3-pip
+
+# ---- 2. EBS 데이터 볼륨 마운트 (venv 보존용) ----
+log "Waiting for EBS data volume..."
+DATA_DISK=""
+for i in $(seq 1 24); do
+  DATA_DISK=$(lsblk -d -o NAME,SIZE | awk '$2=="20G"{print "/dev/"$1}' | head -1)
+  [ -n "$DATA_DISK" ] && break
+  sleep 5
+done
+if [ -z "$DATA_DISK" ]; then
+  log "ERROR: No 20GB data volume found after 2 minutes"
+  exit 1
+fi
+log "Preparing $DATA_DISK -> $DATA_MOUNT..."
+if ! blkid "$DATA_DISK" &>/dev/null; then
+  mkfs.ext4 -F "$DATA_DISK"
+else
+  log "Running e2fsck before mount (self-heal dirty volume)..."
+  e2fsck -y -f "$DATA_DISK" || log "e2fsck exit $? (corrected or non-fatal), continuing"
+fi
+mkdir -p "$DATA_MOUNT"
+if ! mountpoint -q "$DATA_MOUNT"; then
+  log "Mounting $DATA_DISK..."
+  timeout 180 mount "$DATA_DISK" "$DATA_MOUNT" || log "mount returned $? (timeout/err)"
+fi
+if ! mountpoint -q "$DATA_MOUNT"; then
+  log "ERROR: Failed to mount $DATA_DISK to $DATA_MOUNT (volume may be unrecoverable — recreate EBS)"
+  exit 1
+fi
+grep -q "$DATA_DISK" /etc/fstab || echo "$DATA_DISK $DATA_MOUNT ext4 defaults,nofail 0 2" >> /etc/fstab
+
+# ---- 3. OpenSearch API venv ----
+log "Setting up OpenSearch API venv..."
+mkdir -p "$OPENSEARCH_API_DIR"
+# EBS(/data)에 venv 보존 — EC2 재생성 후에도 재설치 스킵
+if [ -f "$DATA_MOUNT/opensearch-api-venv/bin/python" ]; then
+  log "EBS venv exists, skipping torch/transformers install."
+else
+  log "Creating venv and installing torch + transformers..."
+  python3.11 -m venv "$DATA_MOUNT/opensearch-api-venv"
+  "$DATA_MOUNT/opensearch-api-venv/bin/pip" install -q --upgrade pip
+  # CPU-only torch: CUDA 2GB 방지
+  "$DATA_MOUNT/opensearch-api-venv/bin/pip" install -q torch --index-url https://download.pytorch.org/whl/cpu
+  # transformers 4.41.0: 5.x에서 sentence-transformers + torch._dynamo 충돌
+  "$DATA_MOUNT/opensearch-api-venv/bin/pip" install -q "transformers==4.41.0"
+fi
+touch /var/log/venv-ready
+chown -R ubuntu:ubuntu "$OPENSEARCH_API_DIR" "$DATA_MOUNT/opensearch-api-venv"
+
+# ---- 4. OpenSearch API systemd 서비스 ----
+log "Registering opensearch-api service..."
+cat > /etc/systemd/system/opensearch-api.service <<UNIT
+[Unit]
+Description=OpenSearch API Server (ai-innovation)
+After=network.target
+
+[Service]
+Type=simple
+User=ubuntu
+Group=ubuntu
+WorkingDirectory=/opt/opensearch-api
+Environment=OPENSEARCH_URL=https://$OPENSEARCH_HOST:9200
+Environment=OPENSEARCH_HOST=$OPENSEARCH_HOST
+Environment=OPENSEARCH_PORT=9200
+Environment=OPENSEARCH_USE_SSL=true
+Environment=OPENSEARCH_ADMIN_PASSWORD=$OPENSEARCH_ADMIN_PASSWORD
+Environment=INTERNAL_TOKEN=$INTERNAL_TOKEN
+Environment=FORBIDDEN_KEYWORD_JSON_PATH=/opt/opensearch-api/data/forbidden_keyword.json
+ExecStart=$DATA_MOUNT/opensearch-api-venv/bin/uvicorn opensearch_api:app --host 0.0.0.0 --port 8010 --workers 1
+TimeoutStartSec=120
+Restart=always
+RestartSec=5
+StartLimitIntervalSec=120
+StartLimitBurst=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=opensearch-api
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable opensearch-api
+# 이 시점엔 /opt/opensearch-api에 코드가 아직 없음(CI의 별도 SSM 배포 단계에서 채워짐) —
+# 서비스 기동은 그 배포 단계의 마지막에 systemctl restart로 수행.
+
+log "OpenSearch API setup complete."
+touch /var/log/user-data-complete

--- a/infra/ec2/user_data/opensearch_setup.sh
+++ b/infra/ec2/user_data/opensearch_setup.sh
@@ -4,15 +4,15 @@
 # 환경변수는 부트스트랩에서 export된 값을 사용한다:
 #   PROJECT_NAME, OPENSEARCH_VERSION, INTERNAL_TOKEN, OPENSEARCH_ADMIN_PASSWORD
 #
+# opensearch-api(임베딩 추론, KURE-v1)는 더 이상 이 인스턴스에 같이 뜨지 않는다 —
+# opensearch_api_setup.sh로 분리된 별도 EC2에서 돈다(CPU 경합 해소 목적).
+#
 # 메모리 예산 (t3.medium 4GB):
 #   OpenSearch JVM heap: 1000m (실사용 ~1200MB)
-#   opensearch-api + KURE-v1: ~1500MB
 #   OS + SSM: ~600MB
-#   여유: 스왑 4GB로 보완
-# 주의: JVM 1500m 이상 시 KURE-v1 로드 후 SSM 에이전트 OOM으로 배포 불가
+#   여유: 스왑 4GB로 보완(분리 이후 여유 폭 확대 — 필요 시 heap 상향 검토 가능)
 set -euo pipefail
 
-OPENSEARCH_API_DIR="/opt/opensearch-api"
 DATA_MOUNT="/data"
 
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a /var/log/user-data.log; }
@@ -293,84 +293,10 @@ chmod 700 /opt/opensearch-snapshot.sh  # admin 비밀번호 포함 — root 전�
 echo "20 18 * * * root /opt/opensearch-snapshot.sh >> /var/log/opensearch-snapshot.log 2>&1" > /etc/cron.d/opensearch-snapshot
 chmod 644 /etc/cron.d/opensearch-snapshot
 
-# ---- 7. OpenSearch API venv ----
-log "Setting up OpenSearch API venv..."
-mkdir -p "$OPENSEARCH_API_DIR"
-# EBS(/data)에 venv 보존 — EC2 재생성 후에도 재설치 스킵 (~450MB 절감)
-if [ -f "$DATA_MOUNT/opensearch-api-venv/bin/python" ]; then
-  log "EBS venv exists, skipping torch/transformers install."
-else
-  log "Creating venv and installing torch + transformers..."
-  python3.11 -m venv "$DATA_MOUNT/opensearch-api-venv"
-  "$DATA_MOUNT/opensearch-api-venv/bin/pip" install -q --upgrade pip
-  # CPU-only torch: CUDA 2GB 방지
-  "$DATA_MOUNT/opensearch-api-venv/bin/pip" install -q torch --index-url https://download.pytorch.org/whl/cpu
-  # transformers 4.41.0: 5.x에서 sentence-transformers + torch._dynamo 충돌
-  "$DATA_MOUNT/opensearch-api-venv/bin/pip" install -q "transformers==4.41.0"
-fi
-chown -R ubuntu:ubuntu "$OPENSEARCH_API_DIR" "$DATA_MOUNT/opensearch-api-venv"
-
-# ---- 8. OpenSearch API systemd 서비스 ----
-log "Registering opensearch-api service..."
-cat > /etc/systemd/system/opensearch-api.service <<UNIT
-[Unit]
-Description=OpenSearch API Server (ai-innovation)
-After=opensearch.service
-Requires=opensearch.service
-
-[Service]
-Type=simple
-User=ubuntu
-Group=ubuntu
-WorkingDirectory=/opt/opensearch-api
-Environment=OPENSEARCH_URL=https://localhost:9200
-Environment=OPENSEARCH_HOST=localhost
-Environment=OPENSEARCH_PORT=9200
-Environment=OPENSEARCH_USE_SSL=true
-Environment=OPENSEARCH_ADMIN_PASSWORD=$OPENSEARCH_ADMIN_PASSWORD
-Environment=INTERNAL_TOKEN=$INTERNAL_TOKEN
-Environment=FORBIDDEN_KEYWORD_JSON_PATH=/opt/opensearch-api/data/forbidden_keyword.json
-# \$ 이스케이프 필수: unquoted heredoc(<<UNIT)에서 \$ 없이 쓰면 \$(seq 1 60)/\$i가
-# 파일 작성 시점에 확장되어 seq 개행이 unit 파일에 박혀 "bad unit file setting"으로 깨진다.
-# \$ 로 써야 서비스 시작 시점에 bash가 평가한다.
-ExecStartPre=/bin/bash -c 'for i in \$(seq 1 60); do [ -f /var/log/venv-ready ] && exit 0; echo "Waiting for venv (\$i/60)..."; sleep 30; done; exit 1'
-ExecStart=$DATA_MOUNT/opensearch-api-venv/bin/uvicorn opensearch_api:app --host 0.0.0.0 --port 8010 --workers 1
-# venv 대기 루프가 systemd 기본 시작 타임아웃(90초)에 죽지 않도록 연장
-TimeoutStartSec=2400
-Restart=always
-RestartSec=5
-StartLimitIntervalSec=120
-StartLimitBurst=5
-StandardOutput=journal
-StandardError=journal
-SyslogIdentifier=opensearch-api
-
-[Install]
-WantedBy=multi-user.target
-UNIT
-
-systemctl daemon-reload
-systemctl enable opensearch-api
-
-# ---- 9. venv/torch 백그라운드 설치 ----
-# torch CPU 설치는 15~30분 소요. CI 대기를 막지 않도록 백그라운드 실행.
-# opensearch-api.service는 /var/log/venv-ready를 확인한 뒤 기동됨.
-if [ -f "$DATA_MOUNT/opensearch-api-venv/bin/python" ]; then
-  log "EBS venv exists, skipping torch/transformers install."
-  touch /var/log/venv-ready
-else
-  log "Starting background venv install (torch ~20min)..."
-  (
-    python3.11 -m venv "$DATA_MOUNT/opensearch-api-venv"
-    "$DATA_MOUNT/opensearch-api-venv/bin/pip" install -q --upgrade pip
-    "$DATA_MOUNT/opensearch-api-venv/bin/pip" install -q torch --index-url https://download.pytorch.org/whl/cpu
-    "$DATA_MOUNT/opensearch-api-venv/bin/pip" install -q "transformers==4.41.0"
-    chown -R ubuntu:ubuntu "$DATA_MOUNT/opensearch-api-venv"
-    log "Background venv install complete."
-    touch /var/log/venv-ready
-  ) >> /var/log/user-data.log 2>&1 &
-fi
-chown -R ubuntu:ubuntu "$OPENSEARCH_API_DIR" 2>/dev/null || true
+# ---- 7. admin 비밀번호 파일 (opensearch-api가 더 이상 이 인스턴스에 없어 systemd
+# unit에서 추출할 수 없음 — restore_or_skip.sh/create_snapshot.sh가 이 파일에서 읽음) ----
+echo "OPENSEARCH_ADMIN_PASSWORD=$OPENSEARCH_ADMIN_PASSWORD" > /etc/opensearch-admin.env
+chmod 600 /etc/opensearch-admin.env
 
 log "OpenSearch setup complete."
 touch /var/log/user-data-complete

--- a/infra/ec2/variables.tf
+++ b/infra/ec2/variables.tf
@@ -27,6 +27,12 @@ variable "opensearch_setup_hash" {
   default     = "dev"
 }
 
+variable "opensearch_api_setup_hash" {
+  description = "opensearch_api_setup.sh 내용 해시 — opensearch_setup_hash와 동일한 버전 키화 패턴"
+  type        = string
+  default     = "dev"
+}
+
 # ---- 네트워크 ----
 
 variable "vpc_cidr" {
@@ -63,10 +69,19 @@ variable "db_instance_type" {
 
 variable "opensearch_instance_type" {
   description = <<-EOT
-    OpenSearch EC2 인스턴스 타입.
-    OpenSearch JVM(~1.5GB) + opensearch-api 서빙용 KURE-v1(~1.5GB) ≈ 3GB 상주.
-    forbidden 색인 one-shot은 opensearch-api를 정지한 뒤 실행하므로 t3.medium(4GB)+swap로 충분.
+    OpenSearch EC2 인스턴스 타입. opensearch-api(임베딩 추론)는 별도 EC2로 분리되어
+    이 인스턴스엔 OpenSearch JVM(~1.5GB)만 상주 — t3.medium(4GB)+swap로 충분히 여유.
     (과거 색인 크래시는 메모리가 아니라 knn nmslib 네이티브 미탑재 문제였고 lucene 엔진으로 해결됨)
+  EOT
+  type        = string
+  default     = "t3.medium"
+}
+
+variable "opensearch_api_instance_type" {
+  description = <<-EOT
+    OpenSearch API(임베딩 추론, KURE-v1) 전용 EC2 인스턴스 타입.
+    OpenSearch 노드와 분리해 CPU 경합을 없애는 목적 — torch/transformers CPU 추론을
+    안전하게 감당하도록 OpenSearch 인스턴스와 동일 스펙으로 시작.
   EOT
   type        = string
   default     = "t3.medium"
@@ -100,6 +115,18 @@ variable "opensearch_az" {
   description = "OpenSearch EBS 고정 AZ — EC2 재생성 시 EBS가 다른 AZ로 옮겨지지 않도록 고정"
   type        = string
   default     = "ap-northeast-2a"
+}
+
+variable "opensearch_api_az" {
+  description = "OpenSearch API EBS(venv 보존) 고정 AZ — EC2 재생성 시 EBS가 다른 AZ로 옮겨지지 않도록 고정"
+  type        = string
+  default     = "ap-northeast-2a"
+}
+
+variable "opensearch_api_ebs_volume_size_gb" {
+  description = "OpenSearch API venv 보존용 EBS 볼륨 크기 (GB) — torch/transformers만 담으므로 OpenSearch/DB보다 작게"
+  type        = number
+  default     = 20
 }
 
 # ---- ECS ----

--- a/opensearch/create_snapshot.sh
+++ b/opensearch/create_snapshot.sh
@@ -8,11 +8,12 @@ REGION="ap-northeast-2"
 REPO_NAME="s3-backup"             # restore_or_skip.sh / opensearch_setup.sh 일일 cron과 동일 repo로 통일
 SNAPSHOT_NAME="opensearch_snapshot"
 
-# opensearch-api.service 에서 관리자 패스워드 추출
+# /etc/opensearch-admin.env 에서 관리자 패스워드 추출 (opensearch_setup.sh가 작성) —
+# opensearch-api가 별도 EC2로 분리되어 이 인스턴스에는 opensearch-api.service가 없음
 OS_PASSWORD=$(grep -Po 'OPENSEARCH_ADMIN_PASSWORD=\K[^ \n]+' \
-  /etc/systemd/system/opensearch-api.service 2>/dev/null | head -1 || true)
+  /etc/opensearch-admin.env 2>/dev/null | head -1 || true)
 if [ -z "$OS_PASSWORD" ]; then
-  echo "ERROR: OPENSEARCH_ADMIN_PASSWORD를 서비스 파일에서 찾을 수 없습니다."
+  echo "ERROR: OPENSEARCH_ADMIN_PASSWORD를 /etc/opensearch-admin.env에서 찾을 수 없습니다."
   exit 1
 fi
 

--- a/opensearch/index_forbidden.sh
+++ b/opensearch/index_forbidden.sh
@@ -13,7 +13,15 @@ if [ -z "$OS_PW" ]; then
   exit 1
 fi
 
-export OPENSEARCH_HOST=localhost
+# opensearch-api는 OpenSearch 노드와 별도 EC2에서 돈다 — 호스트도 서비스 파일에서 추출
+# (opensearch_api_setup.sh가 OPENSEARCH_HOST를 OpenSearch 인스턴스의 private IP로 박아둔다)
+OS_HOST=$(grep -Po 'OPENSEARCH_HOST=\K[^ ]+' "$SVC" | head -1)
+if [ -z "$OS_HOST" ]; then
+  echo "ERROR: OPENSEARCH_HOST를 서비스 파일에서 찾을 수 없습니다."
+  exit 1
+fi
+
+export OPENSEARCH_HOST="$OS_HOST"
 export OPENSEARCH_PORT=9200
 export OPENSEARCH_USE_SSL=true
 export OPENSEARCH_ADMIN_PASSWORD="$OS_PW"

--- a/opensearch/restore_or_skip.sh
+++ b/opensearch/restore_or_skip.sh
@@ -15,12 +15,13 @@ BASE_PATH="opensearch-snapshots"
 # 앱이 실제 검색에 사용하는 1차 인덱스. 레거시 product_index_v3가 아니라 멀티벡터 v4 기준으로 판단한다.
 PRIMARY_INDEX="product_v4_combined"
 
-# opensearch-api.service 에서 관리자 패스워드 추출
-# SSM 실행 환경에는 OPENSEARCH_ADMIN_PASSWORD가 없으므로 서비스 파일에서 읽음
+# /etc/opensearch-admin.env 에서 관리자 패스워드 추출 (opensearch_setup.sh가 작성)
+# opensearch-api가 별도 EC2로 분리되어 이 인스턴스에는 opensearch-api.service가 없음 —
+# SSM 실행 환경에는 OPENSEARCH_ADMIN_PASSWORD가 없으므로 이 파일에서 읽음
 OS_PASSWORD=$(grep -Po 'OPENSEARCH_ADMIN_PASSWORD=\K[^ \n]+' \
-  /etc/systemd/system/opensearch-api.service 2>/dev/null | head -1 || true)
+  /etc/opensearch-admin.env 2>/dev/null | head -1 || true)
 if [ -z "$OS_PASSWORD" ]; then
-  echo "ERROR: OPENSEARCH_ADMIN_PASSWORD를 서비스 파일에서 찾을 수 없습니다."
+  echo "ERROR: OPENSEARCH_ADMIN_PASSWORD를 /etc/opensearch-admin.env에서 찾을 수 없습니다."
   exit 1
 fi
 


### PR DESCRIPTION
problem:
23~24차 부하테스트에서 배치 인코딩으로 호출 건수를 줄였는데도 OpenSearch EC2 CPU가 100%로 포화되고 완료율이 0%에 머물렀다. 근본 원인은 opensearch-api (SentenceTransformer 임베딩 추론, CPU-bound)가 OpenSearch 노드와 같은 EC2에서 systemd로 같이 떠서, OpenSearch JVM 검색 스레드와 같은 CPU를 나눠 쓰고 있었다는 것 — 타임아웃을 늘려도 이 경합 자체는 해소되지 않음.

as is:
- opensearch_setup.sh가 OpenSearch 설치 + opensearch-api venv/systemd 설치를 한 인스턴스에서 전부 수행
- restore_or_skip.sh / create_snapshot.sh가 opensearch-api.service 파일에서 관리자 비밀번호를 추출(같은 인스턴스 전제)
- index_forbidden.sh가 OPENSEARCH_HOST=localhost로 하드코딩
- ecs.tf의 opensearch_api_url이 OpenSearch 인스턴스의 private_ip를 가리킴

to be:
- OpenSearch 공식 권장사항(ML 워크로드를 데이터/검색 노드와 분리)과 동일한 원칙을, ml-commons 마이그레이션 없이 기존 커스텀 Python 서비스를 그대로 새 EC2로 옮기는 방식으로 구현
- infra/ec2/user_data/opensearch_setup.sh: venv/opensearch-api 섹션 제거, OpenSearch 전용으로 축소. 대신 /etc/opensearch-admin.env에 관리자 비밀번호 기록 (opensearch-api.service가 더 이상 이 인스턴스에 없어 기존 추출 방식이 깨지므로)
- 신규 infra/ec2/user_data/opensearch_api_setup.sh, opensearch_api_server.sh: venv+systemd만 담당, OPENSEARCH_HOST를 OpenSearch 인스턴스의 private IP로 주입
- infra/ec2/ec2.tf: aws_instance.opensearch_api(t3.medium) + 전용 EBS 볼륨 신규
- infra/ec2/security_groups.tf: opensearch_api_ec2 SG 신규, OpenSearch 9200을 이 SG에서만 인바운드 허용, 기존 8010 ECS 인바운드 규칙을 새 SG로 이전
- infra/ec2/ecs.tf, outputs.tf, variables.tf: URL/출력/변수를 새 인스턴스 기준으로 추가·수정
- opensearch/restore_or_skip.sh, create_snapshot.sh: 비밀번호 추출 경로를 /etc/opensearch-admin.env로 변경
- opensearch/index_forbidden.sh: OPENSEARCH_HOST를 서비스 파일에서 동적으로 추출하도록 변경(하드코딩된 localhost 제거)
- .github/workflows/deploy.yml: opensearch_api_setup.sh 해시 업로드/주입, 새 인스턴스 user_data 대기 + SSM 배포 단계 추가, 기존 OpenSearch 배포 단계는 venv/index_forbidden.sh 실행 부분을 제거하고 스냅샷 스크립트 배포만 남김