### PR TITLE
fix: OpenSearch API EBS 데이터 볼륨이 루트 볼륨과 크기 충돌

### DIFF
--- a/infra/ec2/user_data/opensearch_api_setup.sh
+++ b/infra/ec2/user_data/opensearch_api_setup.sh
@@ -35,12 +35,12 @@ apt-get install -y -qq python3.11 python3.11-venv python3-pip
 log "Waiting for EBS data volume..."
 DATA_DISK=""
 for i in $(seq 1 24); do
-  DATA_DISK=$(lsblk -d -o NAME,SIZE | awk '$2=="20G"{print "/dev/"$1}' | head -1)
+  DATA_DISK=$(lsblk -d -o NAME,SIZE | awk '$2=="15G"{print "/dev/"$1}' | head -1)
   [ -n "$DATA_DISK" ] && break
   sleep 5
 done
 if [ -z "$DATA_DISK" ]; then
-  log "ERROR: No 20GB data volume found after 2 minutes"
+  log "ERROR: No 15GB data volume found after 2 minutes"
   exit 1
 fi
 log "Preparing $DATA_DISK -> $DATA_MOUNT..."

--- a/infra/ec2/variables.tf
+++ b/infra/ec2/variables.tf
@@ -124,9 +124,14 @@ variable "opensearch_api_az" {
 }
 
 variable "opensearch_api_ebs_volume_size_gb" {
-  description = "OpenSearch API venv 보존용 EBS 볼륨 크기 (GB) — torch/transformers만 담으므로 OpenSearch/DB보다 작게"
+  description = <<-EOT
+    OpenSearch API venv 보존용 EBS 볼륨 크기 (GB) — torch/transformers만 담으므로
+    OpenSearch/DB보다 작게. 루트 볼륨(20GB)과 다른 크기여야 한다 — 디스크 탐지
+    스크립트(opensearch_api_setup.sh)가 lsblk 사이즈로 데이터 볼륨을 구분하므로
+    같은 크기면 루트 볼륨을 잘못 마운트한다.
+  EOT
   type        = number
-  default     = 20
+  default     = 15
 }
 
 # ---- ECS ----


### PR DESCRIPTION
problem:
새로 분리한 opensearch-api EC2의 user_data가 "Wait for OpenSearch API EC2 user_data to complete" 단계에서 끝나지 않고 계속 대기했다. 원인은 루트 볼륨(20GB)과 venv 보존용 데이터 EBS 볼륨을 똑같이 20GB로 만들어서,
opensearch_api_setup.sh의 디스크 탐지 로직(lsblk 사이즈 매칭)이 둘을 구분하지 못하고 루트 볼륨(nvme0n1)을 잘못 골라 마운트를 시도 → 실패 → 스크립트가
거기서 멈춤(user-data-complete 마커를 못 찍음).

as is:
- variables.tf: opensearch_api_ebs_volume_size_gb 기본값 20 (루트 볼륨과 동일)
- opensearch_api_setup.sh: awk '$2=="20G"'로 데이터 디스크 탐지

to be:
- variables.tf: opensearch_api_ebs_volume_size_gb 기본값 20 → 15로 변경(루트 볼륨과 다른 크기여야 한다는 점을 주석에 명시)
- opensearch_api_setup.sh: awk '$2=="15G"'로 탐지 크기 일치