### PR TITLE
fix: OpenSearch API EBS 데이터 볼륨 크기를 축소가 아닌 증가 방향으로 정정

### DIFF
--- a/infra/ec2/user_data/opensearch_api_setup.sh
+++ b/infra/ec2/user_data/opensearch_api_setup.sh
@@ -35,12 +35,12 @@ apt-get install -y -qq python3.11 python3.11-venv python3-pip
 log "Waiting for EBS data volume..."
 DATA_DISK=""
 for i in $(seq 1 24); do
-  DATA_DISK=$(lsblk -d -o NAME,SIZE | awk '$2=="15G"{print "/dev/"$1}' | head -1)
+  DATA_DISK=$(lsblk -d -o NAME,SIZE | awk '$2=="25G"{print "/dev/"$1}' | head -1)
   [ -n "$DATA_DISK" ] && break
   sleep 5
 done
 if [ -z "$DATA_DISK" ]; then
-  log "ERROR: No 15GB data volume found after 2 minutes"
+  log "ERROR: No 25GB data volume found after 2 minutes"
   exit 1
 fi
 log "Preparing $DATA_DISK -> $DATA_MOUNT..."

--- a/infra/ec2/variables.tf
+++ b/infra/ec2/variables.tf
@@ -128,10 +128,12 @@ variable "opensearch_api_ebs_volume_size_gb" {
     OpenSearch API venv 보존용 EBS 볼륨 크기 (GB) — torch/transformers만 담으므로
     OpenSearch/DB보다 작게. 루트 볼륨(20GB)과 다른 크기여야 한다 — 디스크 탐지
     스크립트(opensearch_api_setup.sh)가 lsblk 사이즈로 데이터 볼륨을 구분하므로
-    같은 크기면 루트 볼륨을 잘못 마운트한다.
+    같은 크기면 루트 볼륨을 잘못 마운트한다. EBS는 축소가 불가능(AWS 제약)하므로
+    반드시 루트 볼륨(20GB)보다 큰 값을 써야 한다 — 작게 가면 in-place resize가
+    "New size cannot be smaller than existing size" 에러로 실패한다.
   EOT
   type        = number
-  default     = 15
+  default     = 25
 }
 
 # ---- ECS ----


### PR DESCRIPTION
problem:
이전 커밋에서 루트 볼륨(20GB)과의 크기 충돌을 피하려고 데이터 볼륨을
20GB → 15GB로 줄였는데, terraform apply가 다음 에러로 실패했다:
"InvalidParameterValue: New size cannot be smaller than existing size" AWS EBS는 in-place resize로 축소를 지원하지 않고, 이 볼륨엔
lifecycle.prevent_destroy = true가 걸려 있어 삭제 후 재생성도 불가능하다. 즉 루트와 다른 크기로 가야 한다는 진단은 맞았지만 방향을 잘못 잡았다.

as is:
- variables.tf: opensearch_api_ebs_volume_size_gb 기본값 15
- opensearch_api_setup.sh: awk '$2=="15G"'로 데이터 디스크 탐지

to be:
- variables.tf: 기본값 15 → 25로 변경(루트 20GB보다 큰 값이어야 AWS가 in-place resize를 허용한다는 점을 주석에 명시)
- opensearch_api_setup.sh: awk '$2=="25G"'로 탐지 크기 일치