### PR TITLE
fix: OpenSearch API EC2를 c5.xlarge로 업사이즈 — t3 패밀리 동일 vCPU 한계 회피

### DIFF
--- a/infra/ec2/variables.tf
+++ b/infra/ec2/variables.tf
@@ -80,11 +80,14 @@ variable "opensearch_instance_type" {
 variable "opensearch_api_instance_type" {
   description = <<-EOT
     OpenSearch API(임베딩 추론, KURE-v1) 전용 EC2 인스턴스 타입.
-    OpenSearch 노드와 분리해 CPU 경합을 없애는 목적 — torch/transformers CPU 추론을
-    안전하게 감당하도록 OpenSearch 인스턴스와 동일 스펙으로 시작.
+    CPU-바운드 인코딩 워크로드라 vCPU 수가 핵심 — t3.medium/t3.large는 둘 다 2 vCPU로
+    동일해서 패밀리 내 단순 업그레이드는 효과가 없다(메모리만 늘어남). c5.xlarge(4 vCPU,
+    컴퓨트 최적화)로 vCPU를 실제로 2배 늘리고, t3 버스터블 인스턴스의 CPU 크레딧 소진에
+    따른 스로틀링 리스크도 같이 없앤다(25차 부하테스트에서 본 지속적 100% CPU 부하는
+    버스터블 인스턴스에 불리한 패턴).
   EOT
   type        = string
-  default     = "t3.medium"
+  default     = "c5.xlarge"
 }
 
 variable "ec2_ami" {

--- a/loadtest/analyze_results.py
+++ b/loadtest/analyze_results.py
@@ -75,6 +75,13 @@ def main() -> None:
     print(f"\nOpenSearch EC2 CPU — 평균: {os_cpu.get('average_of_averages', 'N/A')}, 최대: {os_cpu.get('max', 'N/A')}")
     print(f"\n> {metrics.get('opensearch_note', '')}")
 
+    os_api_cpu = metrics.get("opensearch_api_ec2_cpu", {})
+    if os_api_cpu:
+        print(
+            f"\nOpenSearch API EC2 CPU(임베딩 추론, 25차부터 별도 인스턴스) — "
+            f"평균: {os_api_cpu.get('average_of_averages', 'N/A')}, 최대: {os_api_cpu.get('max', 'N/A')}"
+        )
+
     db_matches = metrics.get("db_pool_log_matches", {})
     print(f"\nDB 풀 고갈 로그 매칭: {db_matches.get('match_count', 'N/A')}건 (상태: {db_matches.get('status', 'N/A')})")
 

--- a/loadtest/fetch_metrics.py
+++ b/loadtest/fetch_metrics.py
@@ -25,6 +25,7 @@ DEFAULT_SERVICES = [
 ]
 DEFAULT_LOG_GROUP = "/ecs/ai-innovation"
 DEFAULT_OPENSEARCH_INSTANCE_ID = "i-0603d62e9349ea0a9"
+DEFAULT_OPENSEARCH_API_INSTANCE_ID = ""  # 25차부터 별도 인스턴스 — 매 테스트 시 현재 ID로 넘겨야 함
 DB_POOL_KEYWORDS = "QueuePool|TimeoutError|SQLSTATE|OperationalError|too many clients|remaining connection|PoolTimeout"
 
 
@@ -106,6 +107,7 @@ def main() -> None:
     parser.add_argument("--services", nargs="+", default=DEFAULT_SERVICES)
     parser.add_argument("--log-group", default=DEFAULT_LOG_GROUP)
     parser.add_argument("--opensearch-instance-id", default=DEFAULT_OPENSEARCH_INSTANCE_ID)
+    parser.add_argument("--opensearch-api-instance-id", default=DEFAULT_OPENSEARCH_API_INSTANCE_ID)
     parser.add_argument("--region", default="ap-northeast-2")
     parser.add_argument("--output", required=True)
     args = parser.parse_args()
@@ -128,6 +130,11 @@ def main() -> None:
         ),
         "db_pool_log_matches": fetch_db_pool_log_matches(logs_client, args.log_group, start, end),
     }
+
+    if args.opensearch_api_instance_id:
+        result["opensearch_api_ec2_cpu"] = fetch_ec2_cpu(
+            cloudwatch, args.opensearch_api_instance_id, start, end
+        )
 
     for service in args.services:
         result["ecs"][service] = {


### PR DESCRIPTION
problem:
25차 부하테스트에서 OpenSearch 노드와의 분리는 성공했지만(OpenSearch CPU 100% 고정 해소), 병목이 OpenSearch API(임베딩 추론) 인스턴스로 옮겨가 동시 100건 부하에서 CPU가 그대로 100%까지 차며 완료율 0%가 재현됐다. ONNX Runtime 백엔드 전환을 검증했으나 KURE-v1 모델에서는 속도 개선이 1.01~1.02x로 사실상 없어 폐기.

as is:
- opensearch_api_instance_type 기본값 t3.medium(2 vCPU)
- t3.medium → t3.large로 단순히 한 단계 올려도 t3.large 역시 2 vCPU라(메모리만 8GB로 증가) CPU 부하 자체에는 아무 효과가 없음
- t3 계열은 버스터블 인스턴스라 지속적인 100% CPU 부하 시 크레딧이 소진되면 베이스라인 성능으로 스로틀링될 수 있음 — 25차에서 본 지속적 포화 패턴과 궁합이 나쁨

to be:
- infra/ec2/variables.tf: opensearch_api_instance_type 기본값을 t3.medium → c5.xlarge로 변경(2 vCPU → 4 vCPU, 컴퓨트 최적화 비-버스터블 인스턴스)
- vCPU를 실제로 2배 늘려 CPU-바운드 인코딩 처리량을 끌어올리고, 크레딧 소진에 따른 스로틀링 리스크도 동시에 제거