### PR TITLE
fix: 품질검사·검색 임베딩 인코딩에 스레드 제한 + 동시성 세마포어 적용

### DIFF
--- a/opensearch/opensearch_api.py
+++ b/opensearch/opensearch_api.py
@@ -3,6 +3,14 @@ import hmac
 import json
 import re
 
+import torch
+
+# 동시 인코딩 요청마다 PyTorch가 내부적으로 모든 코어를 또 쓰면(intra-op parallelism),
+# asyncio.to_thread로 띄운 동시 model.encode() 호출 수만큼 스레드가 중첩 경합한다
+# (예: 동시 인코딩 4건 × 내부 스레드 4개 = 코어 4개를 16개 스레드가 다툼).
+# 1로 고정해 모델 로딩 전에 적용 — 동시성 제어는 아래 _encode_semaphore가 전담한다.
+torch.set_num_threads(1)
+
 from fastapi import FastAPI, HTTPException, Query
 from pydantic import BaseModel, Field, AfterValidator
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -193,6 +201,13 @@ opensearch_client = None
 # 예산을 그대로 사용한다.
 _search_semaphore = asyncio.Semaphore(int(os.getenv("OPENSEARCH_MAX_CONCURRENT_SEARCHES_PER_WORKER", "20")))
 
+# model.encode()는 CPU-바운드라 네트워크 I/O용 _search_semaphore(20)와는 다른 자원이다.
+# 동시 인코딩 수를 vCPU 수에 맞춰 별도로 제한해야 위의 torch.set_num_threads(1)과
+# 같이 적용했을 때 코어가 비지 않으면서도 과도하게 경합하지 않는다.
+# 기본값은 os.cpu_count()로 동적 산출 — 인스턴스 타입이 바뀌어도 코드 수정 없이 맞는다.
+_encode_semaphore = asyncio.Semaphore(
+    int(os.getenv("OPENSEARCH_MAX_CONCURRENT_ENCODES", str(os.cpu_count() or 4)))
+)
 
 # 요청/응답 모델
 class ProductIDSearchRequest(BaseModel):
@@ -524,7 +539,8 @@ async def search_by_product_ids(request: ProductIDSearchRequest):
         )
 
         # 벡터 임베딩 생성
-        query_vector = (await asyncio.to_thread(client.model.encode, request.query)).tolist()
+        async with _encode_semaphore:
+            query_vector = (await asyncio.to_thread(client.model.encode, request.query)).tolist()
         logger.info("query_embedding_created", dimension=len(query_vector))
 
         # Product ID 필터링 쿼리 구성
@@ -649,7 +665,8 @@ async def search_similar_sentences(request: SimilarSentenceRequest):
         client = get_opensearch_client()
 
         # 쿼리 벡터 생성
-        query_vector = (await asyncio.to_thread(client.model.encode, request.query)).tolist()
+        async with _encode_semaphore:
+            query_vector = (await asyncio.to_thread(client.model.encode, request.query)).tolist()
 
         query_body = {
             "size": request.top_k,
@@ -743,7 +760,8 @@ async def search_similar_sentences_batch(request: SimilarSentenceBatchRequest):
 
         async with _search_semaphore:
             # 쿼리 벡터 일괄 생성 — 문장 수만큼 encode를 반복하지 않고 한 번만 호출
-            query_vectors = await asyncio.to_thread(client.model.encode, request.queries)
+            async with _encode_semaphore:
+                query_vectors = await asyncio.to_thread(client.model.encode, request.queries)
 
             batch_results: List[SimilarSentenceBatchResult] = []
             for query, vector in zip(request.queries, query_vectors):
@@ -991,7 +1009,8 @@ async def index_multivector(request: IndexMultivectorRequest):
                 vectordb_id[f"{_INDEX_PREFIX}_{field}"] = []
                 continue
 
-            vectors = await asyncio.to_thread(client.model.encode, sentences, batch_size=64)
+            async with _encode_semaphore:
+                vectors = await asyncio.to_thread(client.model.encode, sentences, batch_size=64)
             index_name = f"{_INDEX_PREFIX}_{field}"
             doc_ids: List[str] = []
             bulk_body = []


### PR DESCRIPTION
problem:
26차 부하테스트에서 OpenSearch API 인스턴스를 t3.medium(2 vCPU)→c5.xlarge(4 vCPU)로 업사이즈했는데도 CPU가 여전히 97~99%까지 차고 완료율 0%가 재현됐다. PyTorch가 model.encode() 호출마다 내부적으로 보이는 모든 코어를 또 쓰는데(intra-op parallelism), asyncio.to_thread로 동시에 여러 encode() 호출이 떠 있으면 "동시 호출 수 × 내부 스레드 수"만큼 스레드가 실제 코어를 두고 경합한다 — vCPU를 늘려도 이 경합 구조 자체는 그대로라 처리량이 비례해서 늘지 않았을 가능성이 있다(가설,
실측 검증은 27차 부하테스트로 진행 예정).

as is:
- torch 스레드 수 제한 없음(기본값 = 코어 수)
- model.encode() 호출 4곳 중 2곳(search_by_product_ids, search_similar_sentences)은 어떤 동시성 제어도 없이 무제한 동시 실행
- 나머지 2곳(search_similar_sentences_batch, index_multivector)은 네트워크 I/O용 _search_semaphore(20)와 같은 자원으로 묶여 있어 CPU-바운드 인코딩에 맞는 상한이 아님

to be:
- opensearch_api.py 최상단에 torch.set_num_threads(1) 추가 — 모델 로딩 전, sentence-transformers를 임포트하는 opensearch_hybrid보다 먼저 적용
- _encode_semaphore 신규 추가(OPENSEARCH_MAX_CONCURRENT_ENCODES, 기본값 os.cpu_count() — 인스턴스 타입이 바뀌어도 코드 수정 없이 자동으로 맞음), 4곳 model.encode() 호출 전부를 이걸로 감쌈
- 기존 _search_semaphore(네트워크 I/O 전용)와 역할 분리, 두 세마포어는 항상 같은 순서(_search_semaphore → _encode_semaphore)로만 중첩 획득돼 데드락 리스크 없음