### PR TITLE
fix: OpenSearch 검색엔진 EC2를 c5.xlarge로 증설 — JVM 힙 1GB→4GB

### DIFF
--- a/infra/DEPLOYMENT_GUIDE.md
+++ b/infra/DEPLOYMENT_GUIDE.md
@@ -506,7 +506,7 @@ terraform apply -var="ecr_image_tag=<직전_정상_SHA>" \
 | crm-service만 안 뜸 | 5432 인바운드 규칙 확인 — LangGraph checkpointer가 PostgreSQL에 직접 연결([security_groups.tf](ec2/security_groups.tf) `ecs_to_postgres`) |
 | ALB 502/503 | Target group unhealthy. `/health` 200 여부, 태스크 기동 여부 확인 |
 | SSE 20초+에서 끊김 | ALB `idle_timeout=300` 적용됐는지([alb.tf](ec2/alb.tf)). CloudFront 경유면 CF 타임아웃도 확인 |
-| OpenSearch OOM | JVM heap 1500m 설정 확인(opensearch_server.sh). t3.medium 메모리 경합 |
+| OpenSearch OOM | JVM heap 4000m 설정 확인(opensearch_setup.sh). c5.xlarge(8GB) 기준 |
 | DB/OpenSearch API 연결 거부 | Phase 6 미수행 — 앱 코드 배포 + `systemctl start` 필요 |
 | terraform `Error acquiring state lock` | DynamoDB 잠금 잔류. `terraform force-unlock <ID>` (신중히) |
 | GitHub Actions OIDC 거부 | Secret `AWS_ROLE_ARN` 오타 또는 부트스트랩 org/repo 불일치 |

--- a/infra/ec2/terraform.tfvars.example
+++ b/infra/ec2/terraform.tfvars.example
@@ -15,7 +15,7 @@ ecr_image_tag = "latest"
 # ---- EC2 ----
 ec2_key_name             = ""           # SSH 키 페어 이름 (없으면 SSM으로 접근)
 db_instance_type         = "t3.medium"
-opensearch_instance_type = "t3.medium"
+opensearch_instance_type = "c5.xlarge"
 ebs_volume_size_gb       = 50
 
 # ---- ECS ----

--- a/infra/ec2/user_data/opensearch_setup.sh
+++ b/infra/ec2/user_data/opensearch_setup.sh
@@ -7,10 +7,10 @@
 # opensearch-api(임베딩 추론, KURE-v1)는 더 이상 이 인스턴스에 같이 뜨지 않는다 —
 # opensearch_api_setup.sh로 분리된 별도 EC2에서 돈다(CPU 경합 해소 목적).
 #
-# 메모리 예산 (t3.medium 4GB):
-#   OpenSearch JVM heap: 1000m (실사용 ~1200MB)
-#   OS + SSM: ~600MB
-#   여유: 스왑 4GB로 보완(분리 이후 여유 폭 확대 — 필요 시 heap 상향 검토 가능)
+# 메모리 예산 (c5.xlarge 8GB, 28차 부하테스트에서 t3.medium 2vCPU/4GB가
+# CPU 99~100% 포화 + 스와핑으로 병목 확인되어 증설):
+#   OpenSearch JVM heap: 4000m (50% 룰)
+#   OS + Lucene 파일 캐시 + SSM: 나머지 ~4GB
 set -euo pipefail
 
 DATA_MOUNT="/data"
@@ -161,11 +161,11 @@ plugins.security.nodes_dn:
   - "CN=opensearch-node-1,O=ai-innovation,C=KR"
 EOF
 
-# JVM heap 1000m — 반드시 1000m 이하 유지 (SSM 에이전트 OOM 방지)
-sed -i 's/-Xms[0-9]*[gGmM]/-Xms1000m/g' /opt/opensearch/config/jvm.options
-sed -i 's/-Xmx[0-9]*[gGmM]/-Xmx1000m/g' /opt/opensearch/config/jvm.options
-grep -q "Xms" /opt/opensearch/config/jvm.options || echo "-Xms1000m" >> /opt/opensearch/config/jvm.options
-grep -q "Xmx" /opt/opensearch/config/jvm.options || echo "-Xmx1000m" >> /opt/opensearch/config/jvm.options
+# JVM heap 4000m — c5.xlarge(8GB) 기준 50% 룰 (나머지는 OS/Lucene 캐시용)
+sed -i 's/-Xms[0-9]*[gGmM]/-Xms4000m/g' /opt/opensearch/config/jvm.options
+sed -i 's/-Xmx[0-9]*[gGmM]/-Xmx4000m/g' /opt/opensearch/config/jvm.options
+grep -q "Xms" /opt/opensearch/config/jvm.options || echo "-Xms4000m" >> /opt/opensearch/config/jvm.options
+grep -q "Xmx" /opt/opensearch/config/jvm.options || echo "-Xmx4000m" >> /opt/opensearch/config/jvm.options
 
 # ---- 플러그인 설치 (반드시 OpenSearch 시작 전) ----
 # 보존 EBS의 product_v4_* 인덱스는 korean_analyzer(nori_tokenizer)에 의존한다.
@@ -214,7 +214,7 @@ systemctl daemon-reload
 systemctl enable opensearch
 systemctl start opensearch
 
-# OpenSearch 기동 대기 (최대 300초 — t3.medium JVM 콜드 스타트 60~150초)
+# OpenSearch 기동 대기 (최대 300초 — c5.xlarge 기준 JVM 콜드 스타트 여유 포함)
 log "Waiting for OpenSearch to be ready..."
 OS_READY=false
 for i in $(seq 1 60); do

--- a/infra/ec2/variables.tf
+++ b/infra/ec2/variables.tf
@@ -70,11 +70,13 @@ variable "db_instance_type" {
 variable "opensearch_instance_type" {
   description = <<-EOT
     OpenSearch EC2 인스턴스 타입. opensearch-api(임베딩 추론)는 별도 EC2로 분리되어
-    이 인스턴스엔 OpenSearch JVM(~1.5GB)만 상주 — t3.medium(4GB)+swap로 충분히 여유.
-    (과거 색인 크래시는 메모리가 아니라 knn nmslib 네이티브 미탑재 문제였고 lucene 엔진으로 해결됨)
+    이 인스턴스엔 OpenSearch JVM만 상주하지만, 28차 부하테스트에서 t3.medium(2 vCPU)
+    자체가 CPU 99~100% 포화 + 메모리 스와핑으로 병목임이 확인됨(burst 크레딧은
+    소진되지 않아 순수 연산량 부족, throttling 문제가 아님). opensearch-api와 동일하게
+    c5.xlarge(4 vCPU, 8GB)로 증설 — vCPU 2배 + JVM 힙을 1GB 하드캡에서 늘릴 메모리 여유 확보.
   EOT
   type        = string
-  default     = "t3.medium"
+  default     = "c5.xlarge"
 }
 
 variable "opensearch_api_instance_type" {


### PR DESCRIPTION
problem:
- 18~28차 부하테스트에서 OpenSearch 검색엔진 EC2(t3.medium, 2vCPU/4GB)가 반복적으로 CPU 99~100% 포화 + 메모리 스와핑을 일으킴
- 28차에서 recommend 핫패스 오버서브스크립션을 고친 뒤에도 동일한 ReadTimeout이 quality_check 단계로 옮겨가며 재현 — 코드 수정만으로는 병목이 파이프라인을 따라 이동할 뿐 해소되지 않음을 확인
- CPU 크레딧이 소진되지 않은 채로 포화 상태였던 것으로 보아 버스트 스로틀링이 아니라 순수 연산량 부족. JVM 힙도 SSM 에이전트 OOM 방지를 위해 1GB로 하드캡되어 있어 벡터 인덱스가 메모리에 충분히 못 올라감

as is:
- opensearch_instance_type: t3.medium (2 vCPU, 4GB)
- JVM heap: -Xms1000m -Xmx1000m (1GB 하드캡)

to be:
- opensearch_instance_type: c5.xlarge (4 vCPU, 8GB) — 이미 동일 스펙으로 증설된 opensearch-api(25차)와 맞춤
- JVM heap: -Xms4000m -Xmx4000m (8GB의 50% 룰)
- DEPLOYMENT_GUIDE.md 트러블슈팅 표의 stale 참조(1500m/opensearch_server.sh/ t3.medium)도 같이 정정