### PR TITLE
fix: quality_check 타임아웃 진단을 위해 http_timeout_short를 10s→120s로 일시 상향

### DIFF
--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -149,7 +149,7 @@ class Settings(BaseSettings):
     port: int = 8005
 
     # HTTP client timeouts (seconds)
-    http_timeout_short: float = 10.0
+    http_timeout_short: float = 120.0
     http_timeout_default: float = 15.0
     http_timeout_long: float = 30.0
     http_timeout_upload: float = 60.0


### PR DESCRIPTION
Problem:
- 29차에서 OpenSearch를 c5.xlarge로 증설해 CPU 포화는 해소했지만 파이프라인 완료율은 여전히 0%
- 품질검사 stage2(OpenSearch 의미 유사도 검사)가 84% 실패(172/205)하는데, 그중 97% (167/172)가 콘텐츠 문제가 아니라 api_unavailable(타임아웃)
- request_id 단위로 실측한 결과 성공 호출은 항상 10초 이내(최대 9.7s), 실패 호출은 정확히 10s×2회 재시도(약 20.5s)에 몰려 있어 10~60초 구간 데이터가 전혀 없음 — http_timeout_short(10s) 자체가 원인인지, OpenSearch API의 _search_semaphore (동시 20개, recommend 단계와 공유) 대기열 경합이 원인인지 현재 데이터로 판단 불가능

as is:
- http_timeout_short: 10.0

to be:
- http_timeout_short: 120.0 (30차 진단용 일시 상향 — 단일 변수만 변경해 결과를 명확히 귀속. 타임아웃을 늘렸을 때 10~120초 구간에서 성공이 나오면 가설 A(타임아웃 부족) 확인, 여전히 120초 벽에 몰리면 가설 B(세마포어 경합) 확인. 결과에 따라 최종값 재확정 또는 세마포어 분리로 전환)