### PR TITLE
fix: Ofix: OpenSearch API 검색 동시성 캡을 20→80으로 증설penSearch API 검색 동시성 캡을…

### DIFF
--- a/infra/ec2/user_data/opensearch_api_setup.sh
+++ b/infra/ec2/user_data/opensearch_api_setup.sh
@@ -98,6 +98,7 @@ Environment=OPENSEARCH_USE_SSL=true
 Environment=OPENSEARCH_ADMIN_PASSWORD=$OPENSEARCH_ADMIN_PASSWORD
 Environment=INTERNAL_TOKEN=$INTERNAL_TOKEN
 Environment=FORBIDDEN_KEYWORD_JSON_PATH=/opt/opensearch-api/data/forbidden_keyword.json
+Environment=OPENSEARCH_MAX_CONCURRENT_SEARCHES_PER_WORKER=80
 ExecStart=$DATA_MOUNT/opensearch-api-venv/bin/uvicorn opensearch_api:app --host 0.0.0.0 --port 8010 --workers 1
 TimeoutStartSec=120
 Restart=always


### PR DESCRIPTION
… 20→80으로 증설

problem:
- 30차에서 http_timeout_short(10s→120s)로 quality_check 타임아웃은 해소했지만, recommend 단계에서 24/100 ReadTimeout이 남음
- 성공한 recommend 76건 중 50건(66%)이 이미 30초를 초과(중간값 96.7s, p99 306.4s)했고, 실패 24건도 노드 시작 후 평균 200초 이상 지나서야 타임아웃 — 개별 호출 하나가 느린 게 아니라 대기열 자체가 깊다는 신호
- recommend(요청당 5회 검색) + quality_check(요청당 최대 3회 검색)가 전부 opensearch_api.py:194의 _search_semaphore(동시 20개) 하나를 공유 — 100명 동시 부하 시 최대 800건이 20개 슬롯에 줄을 섬
- OpenSearch CPU는 29차 증설 이후 평균 13%로 여유 충분 — 연산 부족이 아니라 캡이 새 하드웨어 용량 대비 너무 작게 잡혀 있어 대기열만 깊어지는 것으로 판단

as is:
- OPENSEARCH_MAX_CONCURRENT_SEARCHES_PER_WORKER: 20 (opensearch_api.py 기본값, env 미설정)

to be:
- OPENSEARCH_MAX_CONCURRENT_SEARCHES_PER_WORKER: 80 (opensearch-api.service systemd Environment로 명시 주입, 코드 변경 없음 — 4배 증설로 1차 시도, OpenSearch 재포화 여부는 31차에서 같이 확인)