### PR TITLE
fix: recommend 쿼리 인코딩 5회 호출을 1회 배치 인코딩으로 통합

### DIFF
--- a/backend/app/agents/recommend_product_agent/nodes.py
+++ b/backend/app/agents/recommend_product_agent/nodes.py
@@ -183,16 +183,43 @@ async def recommend_products_node(state: RecommendProductState, config: Runnable
         parsed_data = state.get("parsed_data")
         search_queries = state.get("search_queries")
 
+        # 4개 쿼리 텍스트(retrieval + need/preference/persona)를 한 번에 배치 인코딩 —
+        # 이후 5번의 멀티벡터 검색 호출에서 재사용해 개별 인코딩(5회)을 1회로 줄인다.
+        # 실패 시 None으로 폴백해 기존처럼 호출마다 개별 인코딩하도록 둔다(가용성 우선).
+        retrieval_vector = None
+        query_vectors = None
+        try:
+            vectors = await recommender.product_client._encode_batch([
+                search_queries["retrieval"],
+                search_queries["user_need_query"],
+                search_queries["user_preference_query"],
+                search_queries["persona"],
+            ])
+            retrieval_vector = vectors[0]
+            query_vectors = {
+                "user_need_query": vectors[1],
+                "user_preference_query": vectors[2],
+                "persona": vectors[3],
+            }
+        except Exception as e:
+            logger.warning(
+                "encode_batch_fallback",
+                user_message=f"[{node_name}] 쿼리 배치 인코딩 실패, 개별 인코딩으로 폴백합니다.",
+                error_type=type(e).__name__,
+            )
+
         retrieval_product_ids = await recommender.product_retriever(
             retrieval_query=search_queries["retrieval"],
             brands=parsed_data.get("brands") or None,
-            sub_tags=parsed_data.get("product_categories") or None
+            sub_tags=parsed_data.get("product_categories") or None,
+            retrieval_vector=retrieval_vector,
         )
 
         recommended_products = await recommender.recommend(
             search_queries,
             retrieval_product_ids,
             product_tags=parsed_data.get("product_categories") or None,
+            query_vectors=query_vectors,
         )
         recommended_products = [
             {k: v for k, v in p.items() if not k.endswith("_vector")}

--- a/backend/app/agents/recommend_product_agent/services/recommend_product_in_persona.py
+++ b/backend/app/agents/recommend_product_agent/services/recommend_product_in_persona.py
@@ -111,6 +111,7 @@ class ProductRecommender:
             retrieval_query: str,
             brands: Optional[List[str]],
             sub_tags: Optional[List[str]],
+            retrieval_vector: Optional[List[float]] = None,
         ):
         """필터링된 상품 풀에서 멀티벡터 검색으로 후보 product_id 목록을 반환한다.
 
@@ -118,6 +119,7 @@ class ProductRecommender:
             retrieval_query: 벡터 검색에 사용할 쿼리 문자열
             brands: 브랜드 필터 목록
             sub_tags: 카테고리 태그 목록
+            retrieval_vector: 미리 계산된 retrieval_query 임베딩 (중복 인코딩 방지용)
 
         Returns:
             검색 결과 상위 100개 product_id 문자열 리스트
@@ -127,15 +129,19 @@ class ProductRecommender:
                 sub_tags=sub_tags if sub_tags else None,
             )
 
-        retrieval_result = await self.product_client.search_by_multivector_combined(retrieval_query, filtered_product_ids, top_k=settings.product_retrieval_top_k)
+        retrieval_result = await self.product_client.search_by_multivector_combined(
+            retrieval_query, filtered_product_ids, top_k=settings.product_retrieval_top_k,
+            retrieval_vector=retrieval_vector,
+        )
         retrieval_result_ids = [p['product_id'] for p in retrieval_result]
-        
+
         return retrieval_result_ids
-    
+
     async def get_product_documents(
             self,
             queries: Dict,
-            retrieval_result_ids: List[str]
+            retrieval_result_ids: List[str],
+            query_vectors: Optional[Dict[str, List[float]]] = None,
     ) -> Dict:
         """
         product_retriever로 추려진 상품을 대상으로 페르소나 3개 차원 하이브리드 검색 (병렬)
@@ -146,6 +152,7 @@ class ProductRecommender:
                 - user_preference_query → attribute_desc 필드
                 - persona           → target_user 필드
             retrieval_result_ids: product_retriever 결과 상품 ID 리스트
+            query_vectors: queries와 동일한 키로 미리 계산된 임베딩 (중복 인코딩 방지용)
 
         Returns:
             {
@@ -161,6 +168,7 @@ class ProductRecommender:
         results = await self.product_client.search_persona_dimensions_multivector(
             queries=queries,
             product_ids=retrieval_result_ids,
+            query_vectors=query_vectors,
         )
         logger.info("get_product_documents.done")
         return results
@@ -259,6 +267,7 @@ class ProductRecommender:
         retrieval_result_ids: List[str],
         top_n: int | None = None,
         product_tags: Optional[List[str]] = None,
+        query_vectors: Optional[Dict[str, List[float]]] = None,
     ) -> List[Dict]:
         """
         3차원 하이브리드 검색 + RRF → 상위 top_n개 상품 정보 반환
@@ -268,6 +277,7 @@ class ProductRecommender:
             retrieval_result_ids: product_retriever 결과 상품 ID 리스트
             top_n: 최종 반환할 상품 수 (기본값 3)
             product_tags: 카테고리 태그 리스트. 복수 시 카테고리별 독립 RRF 후 병합
+            query_vectors: queries와 동일한 키로 미리 계산된 임베딩 (중복 인코딩 방지용)
 
         Returns:
             List[Dict]: RRF 순위 기준 상위 top_n개 상품 전체 정보
@@ -275,7 +285,7 @@ class ProductRecommender:
         top_n = top_n if top_n is not None else settings.product_recommendation_top_n
 
         # 3차원 병렬 하이브리드 검색
-        dimension_results = await self.get_product_documents(queries, retrieval_result_ids)
+        dimension_results = await self.get_product_documents(queries, retrieval_result_ids, query_vectors=query_vectors)
 
         # 1차 retrieval 순위를 4번째 차원으로 추가 (추가 API 호출 없음)
         dimension_results["retrieval"] = [

--- a/backend/app/agents/shared/product/product_client.py
+++ b/backend/app/agents/shared/product/product_client.py
@@ -255,6 +255,25 @@ class ProductClient:
             "spec_feature":   settings.opensearch_v4_spec_feature_index,
         }
 
+    async def _encode_batch(self, texts: List[str]) -> List[List[float]]:
+        """POST /api/search/encode/batch 호출 — 여러 쿼리 텍스트를 한 번에 인코딩(검색 없음)"""
+        async with _get_opensearch_semaphore():
+            try:
+                response = await self.http_client.post(
+                    f"{self.vector_db_api_url}/api/search/encode/batch",
+                    json={"texts": texts},
+                )
+                response.raise_for_status()
+                return response.json()["vectors"]
+            except Exception as e:
+                logger.error(
+                    "encode_batch.failed",
+                    text_count=len(texts),
+                    error_type=type(e).__name__,
+                    exc_info=True,
+                )
+                raise
+
     async def _search_multivector(
         self,
         query: str,
@@ -262,19 +281,25 @@ class ProductClient:
         product_ids: List[str],
         top_k: int = 100,
         aggregation: str = "max",
+        query_vector: Optional[List[float]] = None,
     ) -> List[Dict[str, Any]]:
-        """POST /api/search/multivector 호출 (내부용)"""
+        """POST /api/search/multivector 호출 (내부용). query_vector가 주어지면 서버 측
+        인코딩을 스킵하고 그 벡터로 검색만 수행 — 동일 쿼리를 여러 인덱스에 검색할 때
+        중복 인코딩을 피하기 위해 사용."""
         async with _get_opensearch_semaphore():
             try:
+                payload = {
+                    "query": query,
+                    "index_name": index_name,
+                    "product_ids": product_ids,
+                    "top_k": top_k,
+                    "aggregation": aggregation,
+                }
+                if query_vector is not None:
+                    payload["query_vector"] = query_vector
                 response = await self.http_client.post(
                     f"{self.vector_db_api_url}/api/search/multivector",
-                    json={
-                        "query": query,
-                        "index_name": index_name,
-                        "product_ids": product_ids,
-                        "top_k": top_k,
-                        "aggregation": aggregation,
-                    },
+                    json=payload,
                 )
                 response.raise_for_status()
                 return response.json().get("results", [])
@@ -293,6 +318,7 @@ class ProductClient:
         retrieval_query: str,
         product_ids: List[str],
         top_k: int = 100,
+        retrieval_vector: Optional[List[float]] = None,
     ) -> List[Dict[str, Any]]:
         """
         Step 2 (Recall): combined + spec_feature 인덱스 병렬 검색 후 product_id별 max 머지
@@ -301,6 +327,8 @@ class ProductClient:
             retrieval_query: 검색 쿼리
             product_ids: 필터링된 상품 ID 리스트
             top_k: 반환할 최대 상품 수
+            retrieval_vector: 미리 계산된 retrieval_query 임베딩. 주어지면 combined/spec_feature
+                양쪽 검색에 재사용해 동일 쿼리를 두 번 인코딩하지 않음
 
         Returns:
             [{"product_id": str, "score": float}, ...] 내림차순
@@ -315,12 +343,14 @@ class ProductClient:
                 index_name=self._get_v4_indices()["combined"],
                 product_ids=product_ids,
                 top_k=top_k,
+                query_vector=retrieval_vector,
             ),
             self._search_multivector(
                 query=retrieval_query,
                 index_name=self._get_v4_indices()["spec_feature"],
                 product_ids=product_ids,
                 top_k=top_k,
+                query_vector=retrieval_vector,
             ),
         )
 
@@ -342,6 +372,7 @@ class ProductClient:
         queries: Dict[str, str],
         product_ids: List[str],
         top_k: int = 100,
+        query_vectors: Optional[Dict[str, List[float]]] = None,
     ) -> Dict[str, List[Dict[str, Any]]]:
         """
         Step 3 (Rerank): function_desc / attribute_desc / target_user 인덱스 병렬 검색
@@ -350,6 +381,8 @@ class ProductClient:
             queries: get_product_search_queries 반환값
             product_ids: Step 2 결과 상품 ID 리스트
             top_k: 차원별 반환 결과 수
+            query_vectors: queries와 동일한 키(user_need_query/user_preference_query/persona)로
+                미리 계산된 임베딩을 전달하면 서버 측 인코딩을 스킵
 
         Returns:
             {"need": [...], "preference": [...], "persona": [...]}  ← 기존 포맷 동일
@@ -358,24 +391,28 @@ class ProductClient:
             logger.warning("search_persona_dimensions_multivector.no_product_ids")
             return {"need": [], "preference": [], "persona": []}
 
+        query_vectors = query_vectors or {}
         need_result, preference_result, persona_result = await asyncio.gather(
             self._search_multivector(
                 query=queries["user_need_query"],
                 index_name=self._get_v4_indices()["function_desc"],
                 product_ids=product_ids,
                 top_k=top_k,
+                query_vector=query_vectors.get("user_need_query"),
             ),
             self._search_multivector(
                 query=queries["user_preference_query"],
                 index_name=self._get_v4_indices()["attribute_desc"],
                 product_ids=product_ids,
                 top_k=top_k,
+                query_vector=query_vectors.get("user_preference_query"),
             ),
             self._search_multivector(
                 query=queries["persona"],
                 index_name=self._get_v4_indices()["target_user"],
                 product_ids=product_ids,
                 top_k=top_k,
+                query_vector=query_vectors.get("persona"),
             ),
         )
 

--- a/opensearch/opensearch_api.py
+++ b/opensearch/opensearch_api.py
@@ -358,6 +358,10 @@ class MultiVectorSearchRequest(BaseModel):
     top_k: int = Field(default=100, ge=1, le=200, description="반환할 상품 수")
     aggregation: Literal["max", "topk_avg"] = Field(default="max", description="집계 방식")
     pipeline_id: ValidatedPipelineId = Field(default="hybrid-minmax-pipeline")
+    query_vector: Optional[List[float]] = Field(
+        default=None,
+        description="미리 계산된 쿼리 임베딩. 주어지면 서버 측 인코딩을 스킵하고 이 벡터로 검색만 수행",
+    )
 
 
 class MultiVectorSearchResponse(BaseModel):
@@ -366,6 +370,15 @@ class MultiVectorSearchResponse(BaseModel):
     query: str
     index_name: str
     results: List[FieldSearchResult]
+
+
+class EncodeBatchRequest(BaseModel):
+    texts: List[str] = Field(..., description="인코딩할 쿼리 텍스트 리스트", min_length=1, max_length=10)
+
+
+class EncodeBatchResponse(BaseModel):
+    success: bool
+    vectors: List[List[float]] = Field(..., description="texts와 동일한 순서의 임베딩 벡터")
 
 
 class IndexMultivectorRequest(BaseModel):
@@ -955,9 +968,12 @@ async def search_multivector(request: MultiVectorSearchRequest):
 
         pipeline_body = client._create_search_pipe_line_body()
         client.create_search_pipeline(pipeline_id=request.pipeline_id, pipeline_body=pipeline_body)
-        
-        async with _encode_semaphore:
-            query_vector = (await asyncio.to_thread(client.model.encode, request.query)).tolist()
+
+        if request.query_vector is not None:
+            query_vector = request.query_vector
+        else:
+            async with _encode_semaphore:
+                query_vector = (await asyncio.to_thread(client.model.encode, request.query)).tolist()
 
         async with _search_semaphore:
             raw_results = await asyncio.to_thread(
@@ -989,6 +1005,24 @@ async def search_multivector(request: MultiVectorSearchRequest):
     except Exception as e:
         logger.error("search_multivector_failed", exc_info=True)
         raise HTTPException(status_code=500, detail="검색 중 오류가 발생했습니다.")
+
+
+@app.post("/api/search/encode/batch", response_model=EncodeBatchResponse)
+async def encode_batch(request: EncodeBatchRequest):
+    """
+    여러 쿼리 텍스트를 한 번에 인코딩만 수행(검색 없음). recommend_product_agent가
+    한 추천 요청당 여러 인덱스를 검색할 때, 텍스트마다 따로 인코딩을 호출하는 대신
+    한 번에 묶어 호출수를 줄이기 위한 용도 — 반환된 벡터는 /api/search/multivector의
+    query_vector로 재사용한다.
+    """
+    try:
+        client = get_opensearch_client()
+        async with _encode_semaphore:
+            vectors = (await asyncio.to_thread(client.model.encode, request.texts)).tolist()
+        return EncodeBatchResponse(success=True, vectors=vectors)
+    except Exception as e:
+        logger.error("encode_batch_failed", exc_info=True)
+        raise HTTPException(status_code=500, detail="인코딩 중 오류가 발생했습니다.")
 
 
 _MULTIVECTOR_FIELD_NAMES = ["combined", "function_desc", "attribute_desc", "target_user", "spec_feature"]


### PR DESCRIPTION
problem :
recommend_products_node가 요청당 5번의 /api/search/multivector 호출을 보내 매번 개별 인코딩을 수행함 — 그중 Step2의 retrieval_query는 combined/spec_feature 양쪽에 동일 텍스트로 2번 중복 인코딩됨. 31차
부하테스트에서 _search_semaphore 캡을 80으로 풀자 OpenSearch 클러스터는 여유로운데도(최대 46%) 임베딩 인코딩을 전담하는 opensearch-api EC2
(4vCPU)가 99.3%까지 포화되어 recommend ReadTimeout이 거의 줄지 않았다.

as is :
4개의 고유 쿼리 텍스트(retrieval/need/preference/persona)를
검색 호출마다(5회) 따로 model.encode() — quality_check의
similar-sentences/batch가 이미 쓰는 배치 인코딩 패턴을 recommend 쪽엔 적용하지 않고 있었음.

to be :
opensearch_api.py에 /api/search/encode/batch 신규 엔드포인트 추가, /api/search/multivector에는 미리 계산된 query_vector를 받아 서버측 인코딩을 스킵하는 옵션 추가(검색 함수가 이미 지원하던 파라미터를
HTTP 계층까지 노출). recommend_products_node에서 4개 텍스트를 검색 전에 한 번에 배치 인코딩해 5회 검색 호출에 재사용 — 인코딩 호출
5회 → 1회. 배치 인코딩 실패 시 None으로 폴백해 기존 개별 인코딩
경로를 그대로 타도록 가용성을 우선함.