### PR TITLE
fix: deploy.yml의 builder run-instances가 AWS CLI v2에 없는 --min-count/--…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -387,7 +387,7 @@ jobs:
         run: |
           BUILDER_ID=$(aws ec2 run-instances \
             --launch-template "LaunchTemplateId=${{ needs.terraform.outputs.opensearch_api_launch_template_id }},Version=\$Latest" \
-            --min-count 1 --max-count 1 \
+            --count 1 \
             --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=${{ env.PROJECT_NAME }}-opensearch-api-builder}]" \
             --query "Instances[0].InstanceId" --output text)
           echo "builder_id=$BUILDER_ID" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
…max-count로 실패

Problem:
- opensearch-api 빌더 인스턴스 기동 스텝(deploy.yml)이 --min-count 1 --max-count 1로 aws ec2 run-instances를 호출 → "Unknown options" 에러로 워크플로우 즉시 실패

as is:
- AWS CLI v1 시절 문법인 --min-count/--max-count를 그대로 사용
- AWS CLI v2에는 이 두 옵션이 없고 --count 하나로 통합되어 있어 인자 파싱 단계에서 실패

to be:
- --min-count 1 --max-count 1 → --count 1로 교체
- 로컬에서 동일 명령을 --dry-run으로 재현해 정상 파싱되는 것까지 확인