### PR TITLE
fix: opensearch-api 빌더를 매번 새로 띄우는 대신 기존 단일 인스턴스로 고정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -380,53 +380,17 @@ jobs:
       # 단일 EC2에 직접 SSM 배포하던 방식(위 OpenSearch EC2/DB EC2와 동일 패턴)을 더는
       # 쓰지 않는다 — ASG가 매번 새로 띄우는 인스턴스는 그 SSM 배포를 받을 기회가 없어
       # 코드 없이 부팅→크래시 루프에 빠지기 때문(opensearch_api_setup.sh:118 주석).
-      # 대신: 빌더 인스턴스를 하나 띄워 거기에만 SSM으로 코드를 배포하고, 그 결과를
-      # AMI로 굽어 ASG 전체에 instance refresh로 퍼뜨린다.
-      - name: Launch OpenSearch API builder instance
-        id: launch-builder
+      # 대신: 빌더 역할을 기존 단일 인스턴스(aws_instance.opensearch_api)가 그대로 맡는다 —
+      # launch template으로 새 빌더를 매번 띄우면 보조 25GB EBS 데이터 볼륨이 launch
+      # template에 정의돼 있지 않아(block_device_mappings 없음) venv/모델을 찾지 못해 콜드
+      # 부트스트랩이 실패한다. 그 볼륨을 영구히 launch template에 추가하면 골든 AMI가 생긴
+      # 뒤에는 반대로 AMI의 데이터 스냅샷을 빈 볼륨으로 덮어써버리는 문제가 생겨, 두 상태를
+      # 동시에 만족시킬 수 없다. 이미 볼륨/venv/모델이 정상 구성된 기존 인스턴스를 빌더로
+      # 고정하면 이 문제가 원천적으로 없어진다 — 컷오버(opensearch_api_use_nlb=true) 이후
+      # 이 인스턴스를 정리할 때 빌더 전략을 다시 설계해야 한다(지금은 범위 밖).
+      - name: Deploy code to OpenSearch API builder (existing instance) via SSM
         run: |
-          BUILDER_ID=$(aws ec2 run-instances \
-            --launch-template "LaunchTemplateId=${{ needs.terraform.outputs.opensearch_api_launch_template_id }},Version=\$Latest" \
-            --count 1 \
-            --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=${{ env.PROJECT_NAME }}-opensearch-api-builder}]" \
-            --query "Instances[0].InstanceId" --output text)
-          echo "builder_id=$BUILDER_ID" >> "$GITHUB_OUTPUT"
-          echo "Builder instance: $BUILDER_ID"
-
-      - name: Wait for builder boot script to complete
-        run: |
-          BUILDER_ID="${{ steps.launch-builder.outputs.builder_id }}"
-          echo "Waiting for builder ($BUILDER_ID) user_data to complete..."
-          for i in $(seq 1 80); do
-            RESULT=$(aws ssm send-command \
-              --instance-ids "$BUILDER_ID" \
-              --document-name "AWS-RunShellScript" \
-              --parameters '{"commands":["test -f /var/log/user-data-complete && echo OK || echo WAIT"]}' \
-              --output text --query "Command.CommandId" 2>/dev/null || echo "")
-            if [ -n "$RESULT" ]; then
-              sleep 5
-              STATUS=$(aws ssm get-command-invocation \
-                --command-id "$RESULT" \
-                --instance-id "$BUILDER_ID" \
-                --query "StandardOutputContent" --output text 2>/dev/null || echo "WAIT")
-              echo "Attempt $i: $STATUS"
-              if echo "$STATUS" | grep -q "OK"; then
-                echo "Builder boot script complete."
-                break
-              fi
-            else
-              echo "Attempt $i: SSM not reachable yet"
-            fi
-            if [ "$i" = "80" ]; then
-              echo "ERROR: Builder boot script did not complete within 40 minutes."
-              exit 1
-            fi
-            sleep 25
-          done
-
-      - name: Deploy code to builder via SSM
-        run: |
-          BUILDER_ID="${{ steps.launch-builder.outputs.builder_id }}"
+          BUILDER_ID="${{ needs.terraform.outputs.opensearch_api_instance_id }}"
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids "$BUILDER_ID" \
             --document-name "AWS-RunShellScript" \
@@ -469,7 +433,7 @@ jobs:
 
       - name: Verify builder health before baking AMI
         run: |
-          BUILDER_ID="${{ steps.launch-builder.outputs.builder_id }}"
+          BUILDER_ID="${{ needs.terraform.outputs.opensearch_api_instance_id }}"
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids "$BUILDER_ID" \
             --document-name "AWS-RunShellScript" \
@@ -485,10 +449,17 @@ jobs:
       - name: Bake golden AMI from builder
         id: bake-ami
         run: |
-          BUILDER_ID="${{ steps.launch-builder.outputs.builder_id }}"
+          BUILDER_ID="${{ needs.terraform.outputs.opensearch_api_instance_id }}"
+          # --no-reboot: opensearch_api_use_nlb=false(기본값)인 동안은 ECS가 여전히 이
+          # 인스턴스의 private IP로 운영 트래픽을 직접 보낸다. --no-reboot 없이 create-image를
+          # 호출하면 AWS가 파일시스템 일관성을 위해 기본적으로 이 인스턴스를 재부팅시켜,
+          # 컷오버 전까지 배포마다 운영 중인 opensearch-api가 짧게 끊긴다. 직전 SSM 스텝에서
+          # 이미 systemctl restart로 서비스를 깨끗하게 재시작했으므로 --no-reboot로 스냅샷을
+          # 떠도 파일시스템 일관성 위험은 낮다.
           AMI_ID=$(aws ec2 create-image \
             --instance-id "$BUILDER_ID" \
             --name "${{ env.PROJECT_NAME }}-opensearch-api-${{ github.sha }}" \
+            --no-reboot \
             --query "ImageId" --output text)
           echo "ami_id=$AMI_ID" >> "$GITHUB_OUTPUT"
           echo "Waiting for AMI $AMI_ID to become available..."
@@ -531,12 +502,6 @@ jobs:
               exit 1
             fi
           done
-
-      - name: Terminate builder instance
-        if: always()
-        run: |
-          BUILDER_ID="${{ steps.launch-builder.outputs.builder_id }}"
-          [ -n "$BUILDER_ID" ] && aws ec2 terminate-instances --instance-ids "$BUILDER_ID" || true
 
       - name: Restore OpenSearch indices from S3 snapshot if empty
         run: |

--- a/infra/ec2/opensearch_api_asg.tf
+++ b/infra/ec2/opensearch_api_asg.tf
@@ -23,7 +23,16 @@ resource "aws_launch_template" "opensearch_api" {
     name = aws_iam_instance_profile.ec2.name
   }
 
-  vpc_security_group_ids = [aws_security_group.opensearch_api_ec2.id]
+  # subnet_id를 여기 network_interfaces에 박아둔다 — CI가 빌더를 띄울 때
+  # (aws ec2 run-instances --launch-template, ASG 밖에서 단독 실행) subnet을 따로 지정하지
+  # 않아도 항상 ASG와 같은 서브넷/보안그룹으로 뜬다. subnet 없이 vpc_security_group_ids만
+  # 쓰면 AWS가 기본 VPC의 기본 서브넷으로 보내버려 "보안그룹과 서브넷이 다른 네트워크"
+  # 에러가 난다.
+  network_interfaces {
+    associate_public_ip_address = false
+    subnet_id                   = aws_subnet.private[0].id
+    security_groups             = [aws_security_group.opensearch_api_ec2.id]
+  }
 
   # 평소엔 가벼운 경로(시크릿/피어 IP를 env 파일에 써주고 서비스 재시작)만 탄다 — 무거운
   # 설치(apt/venv/torch/모델/코드)는 골든 AMI에 이미 포함돼 있다. 골든 AMI가 아직 없는


### PR DESCRIPTION
problem:
- ASG launch template에 보조 25GB EBS 데이터 볼륨(block_device_mappings)이 없어, 골든 AMI가 아직 없는 상태에서 run-instances로 빌더를 새로 띄우면 venv/모델 볼륨을 못 찾아 콜드 부트스트랩이 실패(40분 타임아웃)
- 단순히 block_device_mappings를 영구 추가하면 골든 AMI가 생긴 뒤에는 반대로 AMI의 데이터 스냅샷을 빈 볼륨으로 덮어써버려, 콜드/웜 두 상태를 launch template 하나로 동시에 만족시킬 수 없음
- (다른 세션 리뷰로 추가 발견) create-image가 --no-reboot 없이 운영 중인 단일 인스턴스를 대상으로 호출되면, 컷오버 전까지는 배포마다 운영 중인 opensearch-api가 재부팅으로 끊김

as is:
- deploy.yml이 매 배포마다 run-instances --launch-template으로 새 빌더를 띄우고 SSM 배포 → AMI 베이크 → terminate
- 빌더에 데이터 볼륨이 없어 콜드 부트스트랩 경로가 실패
- create-image에 --no-reboot 없음

to be:
- 빌더를 기존 단일 인스턴스(aws_instance.opensearch_api, 이미 EBS+venv+모델 정상 구성)로 고정 — run-instances/terminate-instances 단계 제거, SSM 배포·헬스체크·create-image를 전부 그 인스턴스 대상으로 수행
- create-image에 --no-reboot 추가
- launch template은 network_interfaces(서브넷/보안그룹)만 유지, block_device_mappings는 추가하지 않음 — ASG 인스턴스는 골든 AMI의 block device mapping을 그대로 물려받음
- 트레이드오프: 컷오버(opensearch_api_use_nlb=true) 이후 이 단일 인스턴스를 정리할 때 빌더 전략을 다시 설계해야 함(현재 범위 밖, 운영 메모로 남김)