### PR TITLE
feat: opensearch-api 트래픽을 NLB(ASG)로 컷오버

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -134,6 +134,9 @@ jobs:
           TF_VAR_ecr_image_tag: ${{ github.sha }}
           TF_VAR_opensearch_setup_hash:     ${{ steps.setup-hash.outputs.hash }}
           TF_VAR_opensearch_api_setup_hash: ${{ steps.setup-hash-api.outputs.hash }}
+          # ASG/NLB 헬스체크 검증 완료 — opensearch-api 트래픽을 NLB로 컷오버.
+          # 되돌릴 땐 이 값을 false로 바꿔 재배포(무중단 롤백, ecs.tf의 opensearch_api_use_nlb 참고)
+          TF_VAR_opensearch_api_use_nlb: "true"
 
           # ── 시크릿 (GitHub Secrets에서 주입) ──
           TF_VAR_opensearch_admin_password: ${{ secrets.OPENSEARCH_ADMIN_PASSWORD }}


### PR DESCRIPTION
problem:
- ASG/NLB가 생성되고 헬스체크도 healthy지만, opensearch_api_use_nlb 기본값이 false라서 ECS는 여전히 옛 단일 인스턴스로 직접 트래픽을 보내고 있음 — 새 인프라가 실제 트래픽을 받아본 적이 없어, CPU 포화 완화 효과를 검증할 수 없는 상태

as is:
- deploy.yml의 Terraform Apply 스텝이 opensearch_api_use_nlb를 넘기지 않아 항상 기본값(false) 적용 — ecs.tf의 OPENSEARCH_API_URL이 계속 단일 인스턴스 private IP를 가리킴

to be:
- deploy.yml에 TF_VAR_opensearch_api_use_nlb="true" 추가 — 다음 apply부터 ECS가 NLB DNS로 트래픽을 보냄
- 롤백 필요 시 이 값을 false로 바꿔 재배포하면 무중단으로 즉시 되돌릴 수 있음(설계 의도 그대로)