### PR TITLE
fix: deploy.yml builder 헬스체크 재시도 없어 AMI 빌드 직전 단계가 race condition으로 실패

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -437,17 +437,24 @@ jobs:
       - name: Verify builder health before baking AMI
         run: |
           BUILDER_ID="${{ needs.terraform.outputs.opensearch_api_instance_id }}"
-          COMMAND_ID=$(aws ssm send-command \
-            --instance-ids "$BUILDER_ID" \
-            --document-name "AWS-RunShellScript" \
-            --parameters '{"commands":["curl -sf http://localhost:8010/health && echo HEALTH_OK"]}' \
-            --output text --query "Command.CommandId")
-          sleep 10
-          STATUS=$(aws ssm get-command-invocation \
-            --command-id "$COMMAND_ID" --instance-id "$BUILDER_ID" \
-            --query "StandardOutputContent" --output text 2>/dev/null || echo "")
-          echo "$STATUS"
-          echo "$STATUS" | grep -q "HEALTH_OK" || { echo "ERROR: builder /health check failed — aborting before AMI bake"; exit 1; }
+          for i in $(seq 1 12); do
+            COMMAND_ID=$(aws ssm send-command \
+              --instance-ids "$BUILDER_ID" \
+              --document-name "AWS-RunShellScript" \
+              --parameters '{"commands":["curl -sf http://localhost:8010/health && echo HEALTH_OK"]}' \
+              --output text --query "Command.CommandId")
+            sleep 10
+            STATUS=$(aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" --instance-id "$BUILDER_ID" \
+              --query "StandardOutputContent" --output text 2>/dev/null || echo "")
+            echo "Attempt $i: $STATUS"
+            if echo "$STATUS" | grep -q "HEALTH_OK"; then
+              echo "Builder healthy."
+              exit 0
+            fi
+          done
+          echo "ERROR: builder /health check failed after 12 attempts (120s) — aborting before AMI bake"
+          exit 1
 
       - name: Bake golden AMI from builder
         id: bake-ami


### PR DESCRIPTION
problem:
- CI 실행에서 "Verify builder health before baking AMI" 단계가 "ERROR: builder /health check failed — aborting before AMI bake"로 실패
- 직접 SSM으로 점검한 결과 서비스 자체는 정상이었음(curl localhost:8010/health → healthy, journalctl 로그상 정상 기동 완료)

as is:
- 바로 앞 "Deploy code to OpenSearch API builder" 단계의 마지막 명령이 systemctl restart opensearch-api(비동기) — SSM이 "Success"를 보고하는 시점은 재시작 명령을 내렸다는 뜻일 뿐 서비스가 실제로 healthy해졌다는 보장이 없음
- "Verify builder health" 단계는 재시도 로직 없이 단 한 번의 SSM 명령과 sleep 10 (10초)만으로 판정 — 실측한 재시작→healthy 소요시간(약 22초, FastAPI 시작 → OpenSearch 연결 → KURE-v1 모델 로드 → 기동 완료)보다 짧아 타이밍에 따라 실패함

to be:
- "Wait for DB EC2 user_data to complete" 단계(260~282행)와 같은 패턴으로 변경 — 매 반복마다 새 SSM 커맨드를 보내 헬스체크하고, 최대 12회(10초 간격, 최대 120초) 재시도 후에만 최종 실패 처리
- 120초는 실측 소요시간(22초)의 약 5배 여유