### PR TITLE
1번 — ASG 버전 고정, "별도 작업 필요" 주장은 틀렸을 가능성이 높습니다 infra/ec2/opensearch_api…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -463,9 +463,21 @@ jobs:
           # --no-reboot: opensearch_api_use_nlb=false(기본값)인 동안은 ECS가 여전히 이
           # 인스턴스의 private IP로 운영 트래픽을 직접 보낸다. --no-reboot 없이 create-image를
           # 호출하면 AWS가 파일시스템 일관성을 위해 기본적으로 이 인스턴스를 재부팅시켜,
-          # 컷오버 전까지 배포마다 운영 중인 opensearch-api가 짧게 끊긴다. 직전 SSM 스텝에서
-          # 이미 systemctl restart로 서비스를 깨끗하게 재시작했으므로 --no-reboot로 스냅샷을
-          # 떠도 파일시스템 일관성 위험은 낮다.
+          # 컷오버 전까지 배포마다 운영 중인 opensearch-api가 짧게 끊긴다.
+          #
+          # sync 선행: --no-reboot는 재부팅도, 디스크 캐시 flush도 보장하지 않는다 — 직전
+          # 배포 스텝에서 막 tar 압축 해제로 쓴 파일들이 디스크에 완전히 반영되기 전에
+          # 스냅샷이 뜨면, AMI 안 파일이 0바이트로 남는 일이 실제로 발생했다(2026-06-23,
+          # ami-03dfedb55a29740b6 — 배포 종료 13초 후 베이크해서 /opt/opensearch-api 전체가
+          # 0바이트로 굳어버림). systemctl restart만으로는 디스크 flush를 보장하지 않으므로
+          # create-image 호출 전에 SSM으로 sync를 명시적으로 실행한다.
+          SYNC_COMMAND_ID=$(aws ssm send-command \
+            --instance-ids "$BUILDER_ID" \
+            --document-name "AWS-RunShellScript" \
+            --parameters '{"commands":["sync"]}' \
+            --output text --query "Command.CommandId")
+          aws ssm wait command-executed --command-id "$SYNC_COMMAND_ID" --instance-id "$BUILDER_ID"
+          echo "Disk sync complete on builder."
           AMI_ID=$(aws ec2 create-image \
             --instance-id "$BUILDER_ID" \
             --name "${{ env.PROJECT_NAME }}-opensearch-api-${{ github.sha }}" \
@@ -478,12 +490,14 @@ jobs:
 
       - name: Publish new launch template version
         run: |
-          # --source-version 1: Terraform이 관리하는 버전 1(보안그룹/IAM/user_data 등)을
-          # 그대로 물려받고 ImageId만 갱신한다 — $Latest를 source로 쓰면 이전 CI 실행의
-          # 버전을 계속 물고 가게 되어 의도치 않은 드리프트가 누적될 수 있다.
+          # --source-version $Latest: aws_launch_template은 update_default_version=true라서
+          # Terraform이 보안그룹/인스턴스 타입 등을 바꿀 때마다 버전 1을 덮어쓰지 않고 새 버전을
+          # 만들어 default로 승격시킨다. 이 스텝은 직전 terraform apply 이후에 실행되므로
+          # $Latest는 항상 그 최신 Terraform 설정을 가리킨다 — 버전 1로 고정하면 그 이후
+          # Terraform이 만든 모든 변경이 매 배포마다 조용히 되돌려진다.
           aws ec2 create-launch-template-version \
             --launch-template-id "${{ needs.terraform.outputs.opensearch_api_launch_template_id }}" \
-            --source-version 1 \
+            --source-version '$Latest' \
             --launch-template-data "{\"ImageId\":\"${{ steps.bake-ami.outputs.ami_id }}\"}" \
             --version-description "${{ github.sha }}"
 

--- a/opensearch/index_forbidden.sh
+++ b/opensearch/index_forbidden.sh
@@ -1,23 +1,23 @@
 #!/bin/bash
 # forbidden_sentences 색인 one-shot (배포 SSM 단계에서 호출).
-# opensearch-api.service에서 자격증명을 추출해 venv python으로 색인한다.
+# opensearch-api.env(EnvironmentFile)에서 자격증명을 추출해 venv python으로 색인한다.
 # index_forbidden_sentences.py는 count>0면 스킵하는 idempotent 구조.
 # 인라인 SSM 명령의 작은따옴표 충돌을 피하려고 별도 스크립트로 분리 (restore_or_skip.sh와 동일 패턴).
 set -eu
 
-SVC=/etc/systemd/system/opensearch-api.service
+ENV_FILE=/etc/opensearch-api.env
 
-OS_PW=$(grep -Po 'OPENSEARCH_ADMIN_PASSWORD=\K[^ ]+' "$SVC" | head -1)
+OS_PW=$(grep -Po 'OPENSEARCH_ADMIN_PASSWORD=\K[^ ]+' "$ENV_FILE" | head -1)
 if [ -z "$OS_PW" ]; then
-  echo "ERROR: OPENSEARCH_ADMIN_PASSWORD를 서비스 파일에서 찾을 수 없습니다."
+  echo "ERROR: OPENSEARCH_ADMIN_PASSWORD를 환경변수 파일에서 찾을 수 없습니다."
   exit 1
 fi
 
-# opensearch-api는 OpenSearch 노드와 별도 EC2에서 돈다 — 호스트도 서비스 파일에서 추출
+# opensearch-api는 OpenSearch 노드와 별도 EC2에서 돈다 — 호스트도 환경변수 파일에서 추출
 # (opensearch_api_setup.sh가 OPENSEARCH_HOST를 OpenSearch 인스턴스의 private IP로 박아둔다)
-OS_HOST=$(grep -Po 'OPENSEARCH_HOST=\K[^ ]+' "$SVC" | head -1)
+OS_HOST=$(grep -Po 'OPENSEARCH_HOST=\K[^ ]+' "$ENV_FILE" | head -1)
 if [ -z "$OS_HOST" ]; then
-  echo "ERROR: OPENSEARCH_HOST를 서비스 파일에서 찾을 수 없습니다."
+  echo "ERROR: OPENSEARCH_HOST를 환경변수 파일에서 찾을 수 없습니다."
   exit 1
 fi
 


### PR DESCRIPTION
…_asg.tf:71-74를 다시 확인했습니다:   launch_template {   id      = aws_launch_template.opensearch_api.id   version = "$Latest" } 그리고 infra/ec2에는 이 리소스에 대한 lifecycle { ignore_changes = [...] } 블록이 전혀 없습니다(grep으로 확인). AWS provider는 ~> 5.0으로 충분히 최신이라 nested launch_template.version 드리프트 감지가 정상 동작합니다.  즉 인시던트 대응 때 누군가 aws autoscaling update-auto-scaling-group ... --launch-template Version=5로 라이브 상태를 직접 고정했더라도:  HCL 설정은 여전히 리터럴 "$Latest" 다음 terraform apply(=이번에 푸시하는 배포의 Job 2, 매 배포마다 무조건 실행됨, AMI 베이크/인스턴스 리프레시가 일어나는 Job 4보다 먼저 실행됨)가 라이브 값 "5"와 desired "$Latest"의 차이를 감지하고 자동으로 되돌립니다. 따라서 이번 푸시 한 번으로 Job 2가 ASG를 $Latest로 자동 교정하고, 그다음 Job 4가 새로 구운 버전(8)으로 인스턴스 리프레시를 수행합니다. 별도의 수동 ASG 버전 리셋 작업은 필요 없어 보입니다.  다만 제가 라이브 AWS 상태를 직접 조회할 수는 없으니 — 배포 후 aws autoscaling describe-auto-scaling-groups로 LaunchTemplate.Version이 $Latest로 돌아왔는지 확인은 권장합니다. "수동 조치 필요"가 아니라 "자동 교정 여부를 사후 확인"으로 MD에 반영하는 게 정확하다고 봅니다.  2번 (부수 사항) — 맞습니다, 실제로 존재하는 구조적 한계입니다 deploy.yml의 "Deploy code to OpenSearch API builder" 스텝(현재 라인 401~413)을 다시 보면 commands 배열 어디에도 set -e가 없습니다. AWS-RunShellScript는 기본적으로 전체 명령을 하나의 스크립트로 합쳐 실행하고, 종료 코드는 마지막 명령의 exit code로 결정됩니다 — 그래서 index_forbidden.sh가 실패해도 그 뒤의 systemctl restart opensearch-api만 성공하면 SSM 호출 전체가 Success로 보고됩니다. 말씀하신 대로 index_forbidden.sh 한 줄만의 문제가 아니라 이 스텝 전체에 깔린 패턴이고, 지금 막을 필요는 없지만 기록해둘 가치가 있는 한계입니다.  두 내용을 MD에 반영하겠습니다 (1번은 "수동 조치 필요" 대신 "자동 교정되어야 함 — 사후 확인 권장"으로, 2번은 알려진 한계로).

problem:
- 2026-06-23 배포에서 opensearch-api ASG 인스턴스가 전부 크래시루프 — 운영 다운으로 확인됨
- 원인 1: deploy.yml의 "Bake golden AMI from builder"가 --no-reboot로 create-image를 호출하는데, 직전 배포 스텝(tar 압축 해제)이 끝난 지 13초 만에 스냅샷을 떠서 디스크 캐시가 flush되기 전에 찍힘 — 결과 AMI(ami-03dfedb55a29740b6)의 /opt/opensearch-api 전체 파일이 0바이트로 굳음
- 원인 2(부수 발견): "Publish new launch template version"이 항상 --source-version 1로 골든 AMI 버전을 만들어, Terraform이 그 이후 만든 모든 설정 변경(보안그룹/인스턴스 타입 등)이 매 배포마다 조용히 버전 1의 낡은 설정으로 되돌려지는 구조였음
- 원인 3(부수 발견): opensearch/index_forbidden.sh가 OPENSEARCH_ADMIN_PASSWORD/OPENSEARCH_HOST를 /etc/systemd/system/opensearch-api.service에서 grep하는데, 실제 값은 별도 EnvironmentFile인 /etc/opensearch-api.env에 있어 매 배포마다 조용히 실패 중이었음(금지 문장 색인 미갱신 추정)

as is:
- deploy.yml: create-image --no-reboot 호출 전에 디스크 flush를 보장하는 절차가 없었음
- deploy.yml: create-launch-template-version --source-version 1로 고정
- index_forbidden.sh: SVC=/etc/systemd/system/opensearch-api.service에서 자격증명 grep

to be:
- deploy.yml: create-image 호출 전 SSM으로 sync 명령을 보내고 aws ssm wait command-executed로 완료를 명시적으로 기다린 뒤 베이크 진행
- deploy.yml: --source-version '$Latest'로 변경 — 이 스텝은 직전 terraform apply 직후 실행되므로 항상 최신 Terraform 설정을 베이스로 삼게 됨
- index_forbidden.sh: ENV_FILE=/etc/opensearch-api.env로 변경 — opensearch_api_setup.sh/ opensearch_api_asg_boot.sh가 실제로 자격증명을 쓰는 파일과 일치시킴