### PR TITLE
fix: 36차 부하테스트 완료율 폭락(94%→10%) — stage3 LLM judge 레이트리밋 영구실패 방지

### DIFF
--- a/backend/app/agents/generate_message_agent/nodes.py
+++ b/backend/app/agents/generate_message_agent/nodes.py
@@ -170,7 +170,7 @@ async def quality_check_node(state: GenerateMessageState, config: RunnableConfig
     checker = services.checker
     agent_logger = AgentLogger(state, node_name="quality_check_node")
     model = config.get("configurable", {}).get("model", settings.chatgpt_model_name)
-    judge_llm = get_llm(model, temperature=settings.llm_temperature_classifier, reasoning_effort="minimal")
+    judge_llm = get_llm(model, temperature=settings.llm_temperature_classifier, reasoning_effort="low")
 
     generated_tasks = state.get("generated_tasks") or []
     persona_id = state.get("persona_id") or state.get("active_persona_id")

--- a/backend/app/agents/generate_message_agent/services/quality_check.py
+++ b/backend/app/agents/generate_message_agent/services/quality_check.py
@@ -63,6 +63,36 @@ def _is_hedge_without_assertion(query_sentence: str) -> bool:
 
 
 # ============================================================
+# 스테이지3 LLM judge 일시적 오류 재시도
+# ============================================================
+
+# provider 무관 재시도 판별 — openai.RateLimitError 등 provider 전용 클래스를 import하면
+# llm이 Anthropic/Gemini일 때 잡지 못한다. type(e).__name__만으로 판별한다.
+# "TimeoutError"는 OpenAI SDK 자체 타임아웃이 아니라 _run_llm_judge가 거치는
+# ainvoke_with_timeout(core/llm_utils.py:9)의 asyncio.wait_for가 던지는
+# asyncio.TimeoutError(3.11+에서 builtin TimeoutError와 동일 클래스)다. 부하로 호출이
+# 늦어지면 이 경로로도 떨어질 수 있어 반드시 포함해야 한다.
+_RETRYABLE_LLM_ERROR_NAMES = frozenset({
+    "RateLimitError", "APITimeoutError", "APIConnectionError", "InternalServerError",
+    "TimeoutError",
+})
+
+# judge 호출 전용 동시성 제한 — product_client.py의 _opensearch_semaphore와 동일한
+# lazy 초기화 패턴(opensearch_max_concurrent_searches:20 참고). 36차 부하테스트에서
+# reasoning_effort를 낮춰 judge 호출이 9배 빨라지자 동시 100개 요청이 단위 시간당
+# OpenAI로 보내는 호출량도 그만큼 늘어 RateLimitError가 다발했다 — 호출이 거치는
+# 외부 자원(OpenAI API)에만 별도 한도를 둬서 전체 파이프라인 동시성과 분리한다.
+_llm_judge_semaphore: asyncio.Semaphore | None = None
+
+
+def _get_llm_judge_semaphore() -> asyncio.Semaphore:
+    global _llm_judge_semaphore
+    if _llm_judge_semaphore is None:
+        _llm_judge_semaphore = asyncio.Semaphore(settings.quality_check_llm_judge_max_concurrency)
+    return _llm_judge_semaphore
+
+
+# ============================================================
 # 품질 검사 서비스 클래스
 # ============================================================
 
@@ -569,49 +599,56 @@ class QualityChecker:
             scores는 accuracy·tone·personalization·naturalness·safety·overall·feedback 키를 포함.
             LLM 호출 오류 시 ``(False, {"feedback": 오류 메시지})``.
         """
-        try:
-            brand_tone = get_brand_tone(brand_name)
+        brand_tone = get_brand_tone(brand_name)
 
-            system_prompt, human_prompt = build_quality_check_prompt(
-                brand_name=brand_name,
-                product_name=product_name,
-                product_info=product,
-                purpose=purpose,
-                brand_tone=brand_tone,
-                title=title,
-                message=message,
-                persona_info=persona_info,
-            )
-            prompt_messages = [
-                SystemMessage(content=system_prompt),
-                HumanMessage(content=human_prompt),
-            ]
+        system_prompt, human_prompt = build_quality_check_prompt(
+            brand_name=brand_name,
+            product_name=product_name,
+            product_info=product,
+            purpose=purpose,
+            brand_tone=brand_tone,
+            title=title,
+            message=message,
+            persona_info=persona_info,
+        )
+        prompt_messages = [
+            SystemMessage(content=system_prompt),
+            HumanMessage(content=human_prompt),
+        ]
+        judge = llm.with_structured_output(LLMJudgeOutput)
 
-            judge = llm.with_structured_output(LLMJudgeOutput)
-            result: LLMJudgeOutput = await ainvoke_with_timeout(judge, prompt_messages)
+        async with _get_llm_judge_semaphore():
+            for attempt in range(1, settings.quality_check_llm_judge_max_retries + 1):
+                try:
+                    result: LLMJudgeOutput = await ainvoke_with_timeout(judge, prompt_messages)
 
-            scores = {
-                "accuracy": result.accuracy,
-                "tone": result.tone,
-                "personalization": result.personalization,
-                "naturalness": result.naturalness,
-                "cta_clarity": result.cta_clarity,
-                "overall": round(
-                    (result.accuracy + result.tone + result.personalization
-                     + result.naturalness + result.cta_clarity) / 5.0, 2
-                ),
-                "feedback": result.feedback,
-            }
+                    scores = {
+                        "accuracy": result.accuracy,
+                        "tone": result.tone,
+                        "personalization": result.personalization,
+                        "naturalness": result.naturalness,
+                        "cta_clarity": result.cta_clarity,
+                        "overall": round(
+                            (result.accuracy + result.tone + result.personalization
+                             + result.naturalness + result.cta_clarity) / 5.0, 2
+                        ),
+                        "feedback": result.feedback,
+                    }
 
-            # 코드가 직접 판정: 모든 항목 3점 이상 AND 평균 4점 이상
-            score_keys = ("accuracy", "tone", "personalization", "naturalness", "cta_clarity")
-            passed = (
-                all(scores[k] >= settings.quality_check_llm_min_score for k in score_keys)
-                and scores["overall"] >= settings.quality_check_llm_min_overall_score
-            )
-            return passed, scores
+                    # 코드가 직접 판정: 모든 항목 3점 이상 AND 평균 4점 이상
+                    score_keys = ("accuracy", "tone", "personalization", "naturalness", "cta_clarity")
+                    passed = (
+                        all(scores[k] >= settings.quality_check_llm_min_score for k in score_keys)
+                        and scores["overall"] >= settings.quality_check_llm_min_overall_score
+                    )
+                    return passed, scores
 
-        except Exception as e:
-            logger.error("llm_judge_failed", error_type=type(e).__name__, exc_info=True)
-            return False, {"feedback": "LLM 평가 중 오류가 발생했습니다."}
+                except Exception as e:
+                    is_retryable = type(e).__name__ in _RETRYABLE_LLM_ERROR_NAMES
+                    if is_retryable and attempt < settings.quality_check_llm_judge_max_retries:
+                        logger.warning("llm_judge_retry", error_type=type(e).__name__, attempt=attempt)
+                        await asyncio.sleep(settings.quality_check_retry_backoff_base * (2 ** (attempt - 1)))
+                        continue
+                    logger.error("llm_judge_failed", error_type=type(e).__name__, exc_info=True)
+                    return False, {"feedback": "LLM 평가 중 오류가 발생했습니다."}
 

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -201,6 +201,8 @@ class Settings(BaseSettings):
     # Quality check — LLM judge scoring
     quality_check_llm_min_score: int = 3
     quality_check_llm_min_overall_score: int = 4
+    quality_check_llm_judge_max_retries: int = 2
+    quality_check_llm_judge_max_concurrency: int = 40
 
     # HTTP streaming timeouts (SSE proxy)
     http_timeout_stream_connect: float = 10.0


### PR DESCRIPTION
problem:
quality_check stage3 LLM judge 호출 속도를 reasoning_effort="minimal"로 개선했더니 (중앙값 16.47s→1.85s, 약 9배) 36차 부하테스트에서 파이프라인 완료율이 94%→10%로 폭락했다. stage3 실패 500건 샘플 분석 결과 386건이 OpenAI RateLimitError였고 (진짜 저점수 거부는 9건, 정상 통과 105건), _run_llm_judge에 재시도/백오프가 전혀 없어 일시적 레이트리밋 한 번만 떠도 그 즉시 해당 quality_check 라운드가 영구 실패로 처리됐다. 호출이 느릴 때는 "느림 자체가 자연 스로틀"이 되어 분당 호출량이
우연히 OpenAI 한도 밑에 머물렀는데, 호출이 빨라지자 같은 동시 요청 수(100)에서 단위 시간당 호출량도 늘어 처음으로 한도를 넘었다.

as is:
- nodes.py: judge_llm = get_llm(model, ..., reasoning_effort="minimal")
- quality_check.py: _run_llm_judge가 LLM 호출 1회 실패 시(RateLimitError 포함 모든 예외) 재시도 없이 즉시 (False, 오류 메시지) 반환
- judge 호출에 동시성 제한 없음 — chat_stream_max_concurrent=100(요청 단위 게이트) 과 OpenAI API 사이에 별도 계층이 없어 요청 동시성이 곧 judge 호출 동시성

to be:
- nodes.py: reasoning_effort="low"로 완화(속도 개선은 유지하되 레이트리밋 노출 감소)
- quality_check.py: _run_llm_judge에 재시도/백오프 추가 — RateLimitError/ APITimeoutError/APIConnectionError/InternalServerError/TimeoutError(provider 무관, type(e).__name__ 기준 판별, asyncio.wait_for의 TimeoutError 경로 포함)만 최대 2회, 0.5s/1s 백오프로 재시도(_search_sentences_batch의 기존 재시도 패턴 재사용). judge 호출 전체를 감싸는 전용 동시성 세마포어 추가 (_get_llm_judge_semaphore, product_client.py의 _opensearch_semaphore와 동일한 lazy 초기화 패턴) — 전체 파이프라인 동시성과 분리해 OpenAI API에만 별도 상한 부여
- settings.py: quality_check_llm_judge_max_retries=2, quality_check_llm_judge_max_concurrency=40 추가