### PR TITLE
fix: RemoteProtocolError 재시도 + opensearch-api 트래픽 분산 개선

### DIFF
--- a/backend/app/agents/generate_message_agent/services/quality_check.py
+++ b/backend/app/agents/generate_message_agent/services/quality_check.py
@@ -599,23 +599,27 @@ class QualityChecker:
             scores는 accuracy·tone·personalization·naturalness·safety·overall·feedback 키를 포함.
             LLM 호출 오류 시 ``(False, {"feedback": 오류 메시지})``.
         """
-        brand_tone = get_brand_tone(brand_name)
+        try:
+            brand_tone = get_brand_tone(brand_name)
 
-        system_prompt, human_prompt = build_quality_check_prompt(
-            brand_name=brand_name,
-            product_name=product_name,
-            product_info=product,
-            purpose=purpose,
-            brand_tone=brand_tone,
-            title=title,
-            message=message,
-            persona_info=persona_info,
-        )
-        prompt_messages = [
-            SystemMessage(content=system_prompt),
-            HumanMessage(content=human_prompt),
-        ]
-        judge = llm.with_structured_output(LLMJudgeOutput)
+            system_prompt, human_prompt = build_quality_check_prompt(
+                brand_name=brand_name,
+                product_name=product_name,
+                product_info=product,
+                purpose=purpose,
+                brand_tone=brand_tone,
+                title=title,
+                message=message,
+                persona_info=persona_info,
+            )
+            prompt_messages = [
+                SystemMessage(content=system_prompt),
+                HumanMessage(content=human_prompt),
+            ]
+            judge = llm.with_structured_output(LLMJudgeOutput)
+        except Exception as e:
+            logger.error("llm_judge_failed", error_type=type(e).__name__, exc_info=True)
+            return False, {"feedback": "LLM 평가 중 오류가 발생했습니다."}
 
         async with _get_llm_judge_semaphore():
             for attempt in range(1, settings.quality_check_llm_judge_max_retries + 1):

--- a/backend/app/agents/shared/product/product_client.py
+++ b/backend/app/agents/shared/product/product_client.py
@@ -5,6 +5,7 @@ from ....config.settings import settings
 from ....core.http_client_registry import register
 import httpx
 import asyncio
+import random
 
 logger = get_logger("recommend_products")
 
@@ -18,12 +19,43 @@ def _get_opensearch_semaphore() -> asyncio.Semaphore:
     return _opensearch_semaphore
 
 
+# get_products_detail_from_db — keep-alive 커넥션 재사용 레이스로 인한 RemoteProtocolError
+# 재시도. 클라이언트(httpx)/서버(uvicorn) keep-alive 타이머가 우연히 같은 기본값(5s)이라
+# 부하 시 죽은 풀 커넥션을 재사용하다 발생한다(37차 부하테스트 idx 23). GET(멱등)이라
+# 백오프 없이 즉시 재시도해도 안전하다.
+_RETRYABLE_HTTP_ERROR_NAMES = frozenset({"RemoteProtocolError", "ConnectError", "ConnectTimeout"})
+
+
 class ProductClient:
     def __init__(self):
         self.db_api_url = settings.database_api_url
         self.vector_db_api_url = settings.opensearch_api_url
         self._http_client: Optional[httpx.AsyncClient] = None
+        self._request_count = 0
+        self._close_threshold = self._next_close_threshold()
         register(self)
+
+    @staticmethod
+    def _next_close_threshold() -> int:
+        base = settings.http_client_close_every_n_requests
+        jitter = settings.http_client_close_every_n_jitter
+        return base + random.randint(-jitter, jitter)
+
+    async def _maybe_mark_connection_close(self, request: httpx.Request) -> None:
+        """N번째 요청에만 Connection: close를 붙여 그 커넥션 하나만 정상 은퇴시킨다.
+
+        ProductClient는 app.state에 담겨 프로세스 생애주기 동안 재사용되는 싱글턴이라
+        커넥션 풀도 계속 재사용된다 — NLB(L4)는 커넥션 단위로 라우팅을 결정하므로,
+        풀을 안 건드리면 스케일아웃된 새 인스턴스가 트래픽을 받을 기회가 없다(37차
+        부하테스트 — opensearch-api 신규 인스턴스 CPU 4.4%/11.4%에 그침). 풀 전체를
+        교체하지 않고 요청 1건의 커넥션만 닫으므로 asyncio.gather로 동시에 진행 중인
+        다른 요청에는 영향이 없다.
+        """
+        self._request_count += 1
+        if self._request_count >= self._close_threshold:
+            request.headers["Connection"] = "close"
+            self._request_count = 0
+            self._close_threshold = self._next_close_threshold()
 
     @property
     def http_client(self) -> httpx.AsyncClient:
@@ -31,7 +63,9 @@ class ProductClient:
         if self._http_client is None or self._http_client.is_closed:
             self._http_client = httpx.AsyncClient(
                 timeout=httpx.Timeout(settings.http_timeout_long),
+                limits=httpx.Limits(keepalive_expiry=settings.http_keepalive_expiry),
                 headers={"X-Internal-Token": settings.internal_token},
+                event_hooks={"request": [self._maybe_mark_connection_close]},
             )
         return self._http_client
 
@@ -465,15 +499,20 @@ class ProductClient:
     ) -> List[Dict[str, Any]]:
         """정형 DB에서 product_id 리스트로 상품 상세 정보 병렬 조회 (가격, 할인율 등)"""
         async def _fetch_one(product_id: str) -> Optional[Dict[str, Any]]:
-            try:
-                response = await self.http_client.get(
-                    f"{self.db_api_url}/api/products/{product_id}",
-                )
-                response.raise_for_status()
-                return response.json()
-            except Exception as e:
-                logger.error("get_products_detail_from_db.failed", product_id=product_id, error_type=type(e).__name__, exc_info=True)
-                return None
+            for attempt in range(1, settings.db_fetch_max_retries + 1):
+                try:
+                    response = await self.http_client.get(
+                        f"{self.db_api_url}/api/products/{product_id}",
+                    )
+                    response.raise_for_status()
+                    return response.json()
+                except Exception as e:
+                    is_retryable = type(e).__name__ in _RETRYABLE_HTTP_ERROR_NAMES
+                    if is_retryable and attempt < settings.db_fetch_max_retries:
+                        logger.warning("get_products_detail_from_db.retry", product_id=product_id, error_type=type(e).__name__, attempt=attempt)
+                        continue
+                    logger.error("get_products_detail_from_db.failed", product_id=product_id, error_type=type(e).__name__, exc_info=True)
+                    return None
 
         results = await asyncio.gather(*[_fetch_one(pid) for pid in product_ids])
         return [r for r in results if r is not None]

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -153,6 +153,12 @@ class Settings(BaseSettings):
     http_timeout_default: float = 15.0
     http_timeout_long: float = 30.0
     http_timeout_upload: float = 60.0
+    http_keepalive_expiry: float = 30.0
+    http_client_close_every_n_requests: int = 75        # N번째 요청마다 커넥션 1개만 정상 은퇴
+    http_client_close_every_n_jitter: int = 20          # N ± 지터 (여러 인스턴스 동시 은퇴 방지)
+
+    # Database API client — RemoteProtocolError 재시도 (keep-alive 커넥션 레이스)
+    db_fetch_max_retries: int = 2
 
     # File upload background job
     upload_job_ttl_seconds: int = 3600

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -8,4 +8,7 @@ RUN uv pip install --system --no-cache -r requirements.txt
 
 COPY . .
 
-CMD ["uvicorn", "api_server:app", "--host", "0.0.0.0", "--port", "8020"]
+# --timeout-keep-alive 75: 클라이언트(product_client.py, keepalive_expiry=30s)보다
+# 충분히 길게 잡아 keep-alive 커넥션 재사용 레이스를 줄인다. 운영 EC2의
+# infra/ec2/user_data/db_server.sh ExecStart에도 동일 값을 맞춰야 한다.
+CMD ["uvicorn", "api_server:app", "--host", "0.0.0.0", "--port", "8020", "--timeout-keep-alive", "75"]

--- a/infra/ec2/user_data/db_server.sh
+++ b/infra/ec2/user_data/db_server.sh
@@ -132,7 +132,7 @@ Environment=POSTGRES_PASSWORD=$POSTGRES_PASSWORD
 Environment=POSTGRES_DB=$POSTGRES_DB
 Environment=POSTGRES_USER=$POSTGRES_USER
 Environment=POSTGRES_HOST=localhost
-ExecStart=/opt/db-api/venv/bin/uvicorn api_server:app --host 0.0.0.0 --port 8020 --workers 2
+ExecStart=/opt/db-api/venv/bin/uvicorn api_server:app --host 0.0.0.0 --port 8020 --workers 2 --timeout-keep-alive 75
 Restart=always
 RestartSec=5
 StartLimitIntervalSec=120


### PR DESCRIPTION
problem:
37차 부하테스트 분석 중 quality_check_node 외부 호출에서 두 가지 문제가 발견됐다. (1) get_products_detail_from_db가 Database API를 조회하는 중 RemoteProtocolError가 1건 발생해 quality_check 재시도 1회를 그대로 소모시켰다(idx 23). 근본 원인은 클라이언트(httpx)/서버(uvicorn)의 keep-alive 타이머가 둘 다 의도치 않게 같은 기본값 (5초)이라, 부하 시 서버가 막 닫은 죽은 풀 커넥션을 클라이언트가 재사용하다 발생한다. (2) opensearch-api ASG를 1→2로 스케일업해도 새 인스턴스는 거의 트래픽을 못 받았다 (CPU 평균 4.4%/최대 11.4%, 기존 인스턴스는 72.6%/99.6%). NLB(L4)가 TCP 커넥션 단위로 라우팅을 결정하는데, ProductClient가 app.state 싱글턴이라 httpx 커넥션 풀을 프로세스 생애주기 내내 재사용해 커넥션이 재라우팅될 기회 자체가 없었다.

as is:
- settings.py: keep-alive 유휴 타이머, 커넥션 강제 은퇴 주기, DB 재시도 횟수 설정 없음
- product_client.py: get_products_detail_from_db._fetch_one이 예외 발생 시 재시도 없이 즉시 실패. httpx.AsyncClient 생성 시 limits/event_hooks 미설정
- database/Dockerfile, infra/ec2/user_data/db_server.sh: uvicorn 기본 keep-alive 타임아웃(5s) 그대로 사용

to be:
- settings.py: http_keepalive_expiry=30.0, db_fetch_max_retries=2, http_client_close_every_n_requests=75, http_client_close_every_n_jitter=20 추가
- product_client.py: _fetch_one에 RemoteProtocolError/ConnectError/ConnectTimeout (provider 무관, type(e).__name__ 기준) 1회 재시도 추가(멱등 GET이라 백오프 불필요). httpx.AsyncClient에 limits=Limits(keepalive_expiry=30s) 적용해 죽은 커넥션 재사용 빈도 감소. event_hooks={"request": [_maybe_mark_connection_close]}로 N번째(75±20, 인스턴스별 지터) 요청에만 Connection: close 헤더를 붙여 그 커넥션 하나만 정상 은퇴시킴 — 1차 검토했던 "커넥션 풀 전체 교체"(Maximum Connection Age) 방식은 asyncio.gather로 같은 풀을 동시에 쓰는 다른 메서드들의 진행 중인 요청을 강제로 끊을 위험이 있어 폐기하고, 요청 1건의 커넥션만 닫는 방식으로 채택