### PR TITLE
fix: personas/filter gender 완전일치 비교로 조건 검색이 항상 0건 반환

### DIFF
--- a/database/routers/api_endpoints.py
+++ b/database/routers/api_endpoints.py
@@ -489,13 +489,29 @@ async def delete_personas_bulk(
     return {"deleted": deleted}
 
 
+# personas.gender 컬럼에 "남성"/"여성"/영문 "Female" 등 표기가 섞여 있어
+# 동의어 그룹 단위로 매칭한다 (대소문자 무시).
+_GENDER_ALIAS_GROUPS: List[set[str]] = [
+    {"남자", "남성", "male"},
+    {"여자", "여성", "female"},
+]
+
+
+def _gender_match_values(gender: str) -> set[str]:
+    lowered = gender.strip().lower()
+    for group in _GENDER_ALIAS_GROUPS:
+        if lowered in group:
+            return group
+    return {lowered}
+
+
 @router.post("/personas/filter", summary="구조화된 조건으로 페르소나 필터링")
 async def filter_personas(
     request: PersonaFilterRequest,
     db: Session = Depends(get_db),
     x_user_id: str = Depends(get_request_user_id),
 ) -> List[Any]:
-    from sqlalchemy import cast, or_
+    from sqlalchemy import cast, func, or_
     from sqlalchemy.dialects.postgresql import ARRAY
     from sqlalchemy.types import Text
 
@@ -512,7 +528,7 @@ async def filter_personas(
         )
 
     if request.gender is not None:
-        query = query.filter(Persona.gender == request.gender)
+        query = query.filter(func.lower(Persona.gender).in_(_gender_match_values(request.gender)))
     if request.age_min is not None:
         query = query.filter(Persona.age >= request.age_min)
     if request.age_max is not None:


### PR DESCRIPTION
problem:
- "20대 여성/남성 페르소나 목록조회" 등 gender 조건이 들어간 페르소나 검색이 항상 결과 없음으로 응답

as is:
- filter_personas가 Persona.gender == request.gender로 완전일치 비교
- search_tools.py의 PersonaSearchFilter 스키마는 LLM에게 gender를 '남자' 또는 '여자'로 보내도록 안내
- 실제 운영 DB의 personas.gender 컬럼엔 "남자"/"여자" 문자열이 단 한 건도 없음(직접 조회 확인: 여성 222건, Female 56건, 남성 1건, 빈값 1건) — 표기가 "여성"/"남성"(격식체)과 영문 "Female"로 혼재돼 있어 LLM이 보내는 값과 항상 불일치

to be:
- database/routers/api_endpoints.py에 _GENDER_ALIAS_GROUPS({"남자","남성","male"}, {"여자","여성","female"})와 _gender_match_values() 헬퍼 추가
- gender 필터를 func.lower(Persona.gender).in_(_gender_match_values(request.gender))로 변경해 표기 차이(남자/남성/male, 여자/여성/Female)를 동의어 그룹 단위로 매칭하도록 정규화